### PR TITLE
Feature/71/trajectory export

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ license = "BSD-3-Clause"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open"] }
+tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open", "devtools"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trajoptlib = { git = "https://github.com/SleipnirGroup/TrajoptLib.git", rev = "285d0131756dcfe36a5fd0c2a5cb5a73564943cb" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ license = "BSD-3-Clause"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open", "devtools"] }
+tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trajoptlib = { git = "https://github.com/SleipnirGroup/TrajoptLib.git", rev = "285d0131756dcfe36a5fd0c2a5cb5a73564943cb" }

--- a/src/components/navbar/Navbar.module.css
+++ b/src/components/navbar/Navbar.module.css
@@ -2,9 +2,10 @@
   background-color: var(--background-dark-gray);
   border: 1px solid #3f3f3f;
   color: white;
-  display: flex;
-  padding-left: 20px;
-  padding-right: 20px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  padding-left: 0px;
+  padding-right: 0px;
   font-size: 1rem;
   border: 0px;
   align-items: center;

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -25,9 +25,11 @@ class Navbar extends Component<Props, State> {
   render() {
     return (
       <div className={styles.Container}>
-        <span style={{
-          paddingLeft: "16px"
-        }}>
+        <span
+          style={{
+            paddingLeft: "16px",
+          }}
+        >
           <input
             type="file"
             id="file-upload-input"
@@ -61,8 +63,8 @@ class Navbar extends Component<Props, State> {
             >
               <SaveIcon />
             </IconButton>
-            </Tooltip>
-            <Tooltip title="Export Trajectory">
+          </Tooltip>
+          <Tooltip title="Export Trajectory">
             <IconButton
               color="primary"
               onClick={() => {
@@ -73,41 +75,43 @@ class Navbar extends Component<Props, State> {
             </IconButton>
           </Tooltip>
         </span>
-        <span style={{
-            display: "flex",
-            justifyContent: "space-between",
-            paddingInline: "16px",
-          }}>
-        <Divider orientation="vertical" flexItem />
         <span
           style={{
             display: "flex",
             justifyContent: "space-between",
-            paddingLeft: "16px",
+            paddingInline: "16px",
           }}
-          onClick={() => this.context.uiState.setPageNumber(0)}
         >
+          <Divider orientation="vertical" flexItem />
           <span
             style={{
-              minWidth: "20rem",
-              display: "inline-block",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              flexGrow: 1,
-              margin: "auto",
-              flexBasis: 0
+              display: "flex",
+              justifyContent: "space-between",
+              paddingLeft: "16px",
             }}
+            onClick={() => this.context.uiState.setPageNumber(0)}
           >
-            {this.context.model.pathlist.activePath.name}
+            <span
+              style={{
+                minWidth: "20rem",
+                display: "inline-block",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                flexGrow: 1,
+                margin: "auto",
+                flexBasis: 0,
+              }}
+            >
+              {this.context.model.pathlist.activePath.name}
+            </span>
+            <Tooltip title="Open Path Dialog">
+              <IconButton color="default" className={styles.generate}>
+                <ArrowDownIcon />
+              </IconButton>
+            </Tooltip>
           </span>
-          <Tooltip title="Open Path Dialog">
-            <IconButton color="default" className={styles.generate}>
-              <ArrowDownIcon />
-            </IconButton>
-          </Tooltip>
-        </span>
-        <Divider orientation="vertical" flexItem/>
+          <Divider orientation="vertical" flexItem />
         </span>
         <span style={{ textAlign: "right", paddingRight: "16px" }}>
           <Tooltip title="Field Grid">

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -4,6 +4,7 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import SaveIcon from "@mui/icons-material/Save";
 import UploadIcon from "@mui/icons-material/UploadFile";
 import IconButton from "@mui/material/IconButton";
+import FileDownload from "@mui/icons-material/FileDownload";
 import Tooltip from "@mui/material/Tooltip";
 import styles from "./Navbar.module.css";
 import { observer } from "mobx-react";
@@ -24,7 +25,9 @@ class Navbar extends Component<Props, State> {
   render() {
     return (
       <div className={styles.Container}>
-        <span style={{ flexShrink: 0 }}>
+        <span style={{
+          paddingLeft: "16px"
+        }}>
           <input
             type="file"
             id="file-upload-input"
@@ -58,29 +61,42 @@ class Navbar extends Component<Props, State> {
             >
               <SaveIcon />
             </IconButton>
+            </Tooltip>
+            <Tooltip title="Export Trajectory">
+            <IconButton
+              color="primary"
+              onClick={() => {
+                this.context.exportActiveTrajectory();
+              }}
+            >
+              <FileDownload />
+            </IconButton>
           </Tooltip>
         </span>
+        <span style={{
+            display: "flex",
+            justifyContent: "space-between",
+            paddingInline: "16px",
+          }}>
         <Divider orientation="vertical" flexItem />
         <span
           style={{
-            flexShrink: 1,
-            flexGrow: 0,
-            minWidth: 0,
             display: "flex",
             justifyContent: "space-between",
-            paddingInline: "10px",
+            paddingLeft: "16px",
           }}
           onClick={() => this.context.uiState.setPageNumber(0)}
         >
           <span
             style={{
+              minWidth: "20rem",
               display: "inline-block",
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
               flexGrow: 1,
-              minWidth: 0,
               margin: "auto",
+              flexBasis: 0
             }}
           >
             {this.context.model.pathlist.activePath.name}
@@ -91,9 +107,9 @@ class Navbar extends Component<Props, State> {
             </IconButton>
           </Tooltip>
         </span>
-        <Divider orientation="vertical" flexItem />
-
-        <span style={{ flexShrink: 0 }}>
+        <Divider orientation="vertical" flexItem/>
+        </span>
+        <span style={{ textAlign: "right", paddingRight: "16px" }}>
           <Tooltip title="Field Grid">
             <span>
               <IconButton

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -74,7 +74,7 @@ export class DocumentManager {
     const path = this.model.pathlist.paths.get(uuid);
     if (path === undefined) {
       console.error("Tried to export trajectory with unknown uuid: ", uuid);
-     return;
+      return;
     }
     const trajectory = path.getSavedTrajectory();
     if (trajectory === null) {
@@ -86,7 +86,7 @@ export class DocumentManager {
       title: "Save Trajectory",
       defaultPath: `${path.name}.json`,
       filters: [
-        { 
+        {
           name: "Trajopt Trajectory",
           extensions: ["json"],
         },

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -70,7 +70,35 @@ export class DocumentManager {
       .catch((err) => console.log(err));
   }
 
-  async exportTrajectory(uuid: string) {}
+  async exportTrajectory(uuid: string) {
+    const path = this.model.pathlist.paths.get(uuid);
+    if (path === undefined) {
+      console.error("Tried to export trajectory with unknown uuid: ", uuid);
+     return;
+    }
+    const trajectory = path.getSavedTrajectory();
+    if (trajectory === null) {
+      console.error("Tried to export ungenerated trajectory: ", uuid);
+      return;
+    }
+    const content = JSON.stringify(trajectory, undefined, 4);
+    const filePath = await dialog.save({
+      title: "Save Trajectory",
+      defaultPath: `${path.name}.json`,
+      filters: [
+        { 
+          name: "Trajopt Trajectory",
+          extensions: ["json"],
+        },
+      ],
+    });
+    if (filePath) {
+      await fs.writeTextFile(filePath, content);
+    }
+  }
+  async exportActiveTrajectory() {
+    return await this.exportTrajectory(this.model.pathlist.activePathUUID);
+  }
 
   async loadFile(jsonFilename: string) {
     await fetch(jsonFilename, { cache: "no-store" })

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -83,7 +83,7 @@ export class DocumentManager {
     }
     const content = JSON.stringify(trajectory, undefined, 4);
     const filePath = await dialog.save({
-      title: "Save Trajectory",
+      title: "Export Trajectory",
       defaultPath: `${path.name}.json`,
       filters: [
         {


### PR DESCRIPTION
Implemented:
* Button that opens a dialog and writes the active trajectory to the selected file.
   - The default filename in the dialog matches the trajectory name, but the filename can be changed.
   - If the trajectory is null (ungenerated) or the active trajectory uuid (somehow) is not in the pathlist, the saving console-errors out without opening the dialog.
Closes #71 