### PR TITLE
Feature/hamster generating indicator

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ license = "BSD-3-Clause"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open"] }
+tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open", "devtools"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trajoptlib = { git = "https://github.com/SleipnirGroup/TrajoptLib.git", rev = "285d0131756dcfe36a5fd0c2a5cb5a73564943cb" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ license = "BSD-3-Clause"
 tauri-build = { version = "1.4", features = [] }
 
 [dependencies]
-tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open", "devtools"] }
+tauri = { version = "1.4", features = [ "dialog-save", "dialog-open", "fs-all", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trajoptlib = { git = "https://github.com/SleipnirGroup/TrajoptLib.git", rev = "285d0131756dcfe36a5fd0c2a5cb5a73564943cb" }

--- a/src/components/field/Field.tsx
+++ b/src/components/field/Field.tsx
@@ -7,7 +7,8 @@ import styles from "./Field.module.css";
 import FieldOverlayRoot from "./svg/FieldOverlayRoot";
 import IconButton from "@mui/material/IconButton";
 import ShapeLineIcon from "@mui/icons-material/ShapeLine";
-import { Tooltip } from "@mui/material";
+import { CircularProgress, Tooltip } from "@mui/material";
+import Box from "@mui/material/Box/Box";
 
 type Props = {};
 
@@ -26,11 +27,19 @@ export class Field extends Component<Props, State> {
         <Tooltip
           placement="top-start"
           title={
-            this.context.model.pathlist.activePath.canGenerate()
+            this.context.model.pathlist.activePath.canGenerate() ||
+            this.context.model.pathlist.activePath.generating
               ? "Generate Path"
               : "Generate Path (needs 2 waypoints)"
           }
-        >
+        > 
+          <Box sx={{
+            position: "absolute",
+            bottom: 10,
+            right: 10,
+            width: 48,
+            height: 48
+          }}>
           <IconButton
             color="primary"
             aria-label="add"
@@ -38,8 +47,10 @@ export class Field extends Component<Props, State> {
             style={{ pointerEvents: "all" }}
             sx={{
               position: "absolute",
-              bottom: 10,
-              right: 10,
+              bottom: 0,
+              right: 0,
+              width:"100%",
+              height:"100%",
               transformOrigin: "100% 100%",
               transform: "scale(1.3)",
               borderRadius: "50%",
@@ -52,7 +63,19 @@ export class Field extends Component<Props, State> {
           >
             <ShapeLineIcon></ShapeLineIcon>
           </IconButton>
+          </Box>
         </Tooltip>
+        {this.context.model.pathlist.activePath.generating && (
+          <CircularProgress
+            size={48 * 1.3}
+            sx={{
+              color: "var(--select-yellow)",
+              position: "absolute",
+              bottom: 10,
+              right: 10 + 4
+            }}
+          />)}
+          
       </div>
     );
   }

--- a/src/components/field/Field.tsx
+++ b/src/components/field/Field.tsx
@@ -32,37 +32,39 @@ export class Field extends Component<Props, State> {
               ? "Generate Path"
               : "Generate Path (needs 2 waypoints)"
           }
-        > 
-          <Box sx={{
-            position: "absolute",
-            bottom: 10,
-            right: 10,
-            width: 48,
-            height: 48
-          }}>
-          <IconButton
-            color="primary"
-            aria-label="add"
-            size="large"
-            style={{ pointerEvents: "all" }}
+        >
+          <Box
             sx={{
               position: "absolute",
-              bottom: 0,
-              right: 0,
-              width:"100%",
-              height:"100%",
-              transformOrigin: "100% 100%",
-              transform: "scale(1.3)",
-              borderRadius: "50%",
-              boxShadow: "3px",
+              bottom: 10,
+              right: 10,
+              width: 48,
+              height: 48,
             }}
-            onClick={() => {
-              this.context.model.pathlist.activePath.generatePath();
-            }}
-            disabled={!this.context.model.pathlist.activePath.canGenerate()}
           >
-            <ShapeLineIcon></ShapeLineIcon>
-          </IconButton>
+            <IconButton
+              color="primary"
+              aria-label="add"
+              size="large"
+              style={{ pointerEvents: "all" }}
+              sx={{
+                position: "absolute",
+                bottom: 0,
+                right: 0,
+                width: "100%",
+                height: "100%",
+                transformOrigin: "100% 100%",
+                transform: "scale(1.3)",
+                borderRadius: "50%",
+                boxShadow: "3px",
+              }}
+              onClick={() => {
+                this.context.model.pathlist.activePath.generatePath();
+              }}
+              disabled={!this.context.model.pathlist.activePath.canGenerate()}
+            >
+              <ShapeLineIcon></ShapeLineIcon>
+            </IconButton>
           </Box>
         </Tooltip>
         {this.context.model.pathlist.activePath.generating && (
@@ -72,10 +74,10 @@ export class Field extends Component<Props, State> {
               color: "var(--select-yellow)",
               position: "absolute",
               bottom: 10,
-              right: 10 + 4
+              right: 10 + 4,
             }}
-          />)}
-          
+          />
+        )}
       </div>
     );
   }

--- a/src/components/field/Field.tsx
+++ b/src/components/field/Field.tsx
@@ -36,8 +36,8 @@ export class Field extends Component<Props, State> {
           <Box
             sx={{
               position: "absolute",
-              bottom: 10,
-              right: 10,
+              bottom: 16,
+              right: 16,
               width: 48,
               height: 48,
             }}
@@ -57,6 +57,7 @@ export class Field extends Component<Props, State> {
                 transform: "scale(1.3)",
                 borderRadius: "50%",
                 boxShadow: "3px",
+                marginInline: 0,
               }}
               onClick={() => {
                 this.context.model.pathlist.activePath.generatePath();
@@ -73,8 +74,8 @@ export class Field extends Component<Props, State> {
             sx={{
               color: "var(--select-yellow)",
               position: "absolute",
-              bottom: 10,
-              right: 10 + 4,
+              bottom: 16,
+              right: 16,
             }}
           />
         )}


### PR DESCRIPTION
Adds a "Hamster Wheel" user feedback around the generate button.
Also fixes the consistent console error regarding a disabled <IconButton> as a direct child of <Tooltip>
Updates the tooltip on the generate button to avoid showing "Generate Path (needs 2 waypoints)" when the trajectory is generating.
Slightly adjusts positioning of generate button to match MUI's 8-pixel design grid.