### PR TITLE
Modified README.md to reflect usage of tauri instead of electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Choreo (_Constraint-Honoring Omnidirectional Route Editor and Optimizer_) is a g
 
 Grab the latest release for your platform on the [releases](https://github.com/SleipnirGroup/Choreo/releases) page.
 
-## To run in Electron
+## To run in Tauri
 
 - Have Node.js, npm, and rust installed.
 - Navigate to the root directory of the project.


### PR DESCRIPTION
Since it appears that this no longer uses electron and instead uses Tauri (thank god, good idea!), this updates the readme heading to reflect that. May also be better to modify it to just say something along the lines of "How to run dev" or something, not sure.