### PR TITLE
Remove redundant delete key binding

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -147,7 +147,7 @@ export class DocumentManager {
         this.model.select(newWaypoint);
       }
     });
-    hotkeys("del,delete,backspace,clear", () => {
+    hotkeys("delete,backspace,clear", () => {
       const selected = this.getSelectedWaypoint();
       if (selected) {
         this.model.document.pathlist.activePath.deleteWaypointUUID(


### PR DESCRIPTION
Both `del` and `delete` fire on the delete keypress. This results in multiple deletions.

Closes #143 