### PR TITLE
Update tauri allowlist to match cargo.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         run: ls
 
       - name: Build Package
-        run: npm run tauri build
+        run: npm run tauri build -- -v
 
       - name: Upload Bundle
         uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         run: ls
 
       - name: Build Package
-        run: npm run tauri build -- -v
+        run: npm run tauri build
 
       - name: Upload Bundle
         uses: actions/upload-artifact@v3.1.1

--- a/src-tauri/tauri.conf.in.json
+++ b/src-tauri/tauri.conf.in.json
@@ -23,7 +23,14 @@
       "dialog": {
         "confirm": true,
         "open": true,
-        "save": true
+        "save": true,
+        "ask": true
+      },
+      "window": {
+        "setTitle": true
+      },
+      "path": {
+        "all": true
       }
     },
     "bundle": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,10 +26,10 @@ export default defineConfig(async () => ({
     rollupOptions: {
       onwarn(warning, defaultHandler) {
         if (
-          warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
-          warning.message.includes('use client')
+          warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+          warning.message.includes("use client")
         ) {
-          return
+          return;
         }
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,5 +23,15 @@ export default defineConfig(async () => ({
     minify: !process.env.TAURI_DEBUG ? "esbuild" : false,
     // produce sourcemaps for debug builds
     sourcemap: !!process.env.TAURI_DEBUG,
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        if (
+          warning.code === 'MODULE_LEVEL_DIRECTIVE' &&
+          warning.message.includes('use client')
+        ) {
+          return
+        }
+      },
+    },
   },
 }));


### PR DESCRIPTION
`npm install` or at least `node scripts/generate_tauri_conf.cjs` will need to be run after pulling these changes, to recreate the tauri.conf.json.