### PR TITLE
Remove redundant catch in generatePath

### DIFF
--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -110,8 +110,7 @@ const StateStore = types
                 path: pathStore.waypoints,
                 config: self.document.robotConfig,
                 constraints: pathStore.asSolverPath().constraints,
-              }),
-            (e) => e
+              })
           )
           .then(
             (rust_traj) => {

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -104,13 +104,12 @@ const StateStore = types
           pathStore.setGenerating(true);
           resolve(pathStore);
         })
-          .then(
-            () =>
-              invoke("generate_trajectory", {
-                path: pathStore.waypoints,
-                config: self.document.robotConfig,
-                constraints: pathStore.asSolverPath().constraints,
-              })
+          .then(() =>
+            invoke("generate_trajectory", {
+              path: pathStore.waypoints,
+              config: self.document.robotConfig,
+              constraints: pathStore.asSolverPath().constraints,
+            })
           )
           .then(
             (rust_traj) => {


### PR DESCRIPTION
If the promise failed in the step before generation (the path validation), this would catch that failure and pass it as a success value as `rust_traj` and break a bunch of stuff. Users might not notice it but it makes a console error.