### PR TITLE
Add nix-shell development environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,20 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  name = "Choreo";
+
+  packages = with pkgs; [
+    cargo
+    nodejs
+    gcc
+
+    pkg-config
+    cmake
+    webkitgtk
+    gnome.libsoup
+  ];
+
+  shellHook = ''
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/src-tauri
+  '';
+}


### PR DESCRIPTION
This adds a reproducible development environment with all the dependencies you need to build Choreo, plus the dynamic libraries added to `LD_LIBRARY_PATH` for convenience.


I originally hoped to fully build Choreo with Nix (rather than just a development shell to build it in), but I unfortunately wasn't able to get it working. It's particularly difficult because there are three different build systems involved (four counting Nix itself) and I wasn't able to get CMake to build trajoptlib without accessing the Internet sadly.
