### PR TITLE
Vendor UI fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "choreo",
-  "version": "0.3.0",
+  "version": "2024.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "choreo",
-      "version": "0.3.0",
+      "version": "2024.0.4",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fontsource/roboto": "^5.0.8",
+        "@fontsource/source-code-pro": "^5.0.16",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.6",
         "@tauri-apps/api": "^1.4.0",
@@ -876,6 +878,16 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.8.tgz",
+      "integrity": "sha512-XxPltXs5R31D6UZeLIV1td3wTXU3jzd3f2DLsXI8tytMGBkIsGcc9sIyiupRtA8y73HAhuSCeweOoBqf6DbWCA=="
+    },
+    "node_modules/@fontsource/source-code-pro": {
+      "version": "5.0.16",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-code-pro/-/source-code-pro-5.0.16.tgz",
+      "integrity": "sha512-ErErGXjKo9/fAJE49fyU8M6DuJUpdqR5YLM8jGJOC5ZcKIDSTQ5m+R3DTa0VYHAGGFbk2qLWVWD/r5sfCLA/jQ=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@fontsource/roboto": "^5.0.8",
+    "@fontsource/source-code-pro": "^5.0.16",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.6",
     "@tauri-apps/api": "^1.4.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles.css";
+import "@fontsource/roboto";
+import "@fontsource/source-code-pro";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App />


### PR DESCRIPTION
Right now, Choreo relies on the system's available fonts, which is inconsistent and makes for a bad UI if users have bad default fonts installed. This PR vendors Roboto and Source Code Pro, which are the most-preferred free fonts in the font-family directives Choreo currently has.

It might also be good to use exclusively these two fonts for improved consistency on macOS and Windows.
