### PR TITLE
Fix bug regarding input exiting without changing

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -40,7 +40,7 @@ class Input extends Component<Props, State> {
     this.setState({
       focused: false,
       editing: false,
-      editedValue: this.props.number.toString()
+      editedValue: this.props.number.toString(),
     });
   }
 
@@ -48,7 +48,7 @@ class Input extends Component<Props, State> {
     this.setState({
       focused: true,
       editing: false,
-      editedValue: this.props.number.toString()
+      editedValue: this.props.number.toString(),
     });
     this.inputElemRef.current!.value = this.props.number.toString();
     this.inputElemRef.current!.select();

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -40,6 +40,7 @@ class Input extends Component<Props, State> {
     this.setState({
       focused: false,
       editing: false,
+      editedValue: this.props.number.toString()
     });
   }
 
@@ -47,6 +48,7 @@ class Input extends Component<Props, State> {
     this.setState({
       focused: true,
       editing: false,
+      editedValue: this.props.number.toString()
     });
     this.inputElemRef.current!.value = this.props.number.toString();
     this.inputElemRef.current!.select();


### PR DESCRIPTION
Entering and exiting an input element without changing the value will set the value to the last committed value, which might be for a different piece of data.

Steps to reproduce:
1. Create 2 waypoints. Select the first
2. Change its x coordinate and exit the input using Enter or clicking away. 
3. Select the other waypoint. 
4. Click into its x coordinate input and exit the input without changing anything.
5. The x coordinate of the second input will reset to the value of the the first