### PR TITLE
Block spacebar "repeat last button" MUI accessibility keybind

### DIFF
--- a/src/components/field/PathAnimationPanel.tsx
+++ b/src/components/field/PathAnimationPanel.tsx
@@ -67,7 +67,8 @@ class PathAnimationPanel extends Component<Props, State> {
     }
   }
   componentDidMount(): void {
-    hotkeys("space", "all", () => {
+    hotkeys("space", "all", (e) => {
+      e.preventDefault();
       if (this.state.running) {
         this.onStop();
       } else {


### PR DESCRIPTION
MUI by default interprets a spacebar press as a click event on the focused element. This accessibility feature needs to be avoided, since we use spacebar for play/pause.