### PR TITLE
Docs Enhancement: Hide TOC and navigation from Home Page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,15 @@
+---
+hide:
+  - toc
+  - navigation
+---
+
+!!! tip inline end
+
+    See the navigation links in the header or side-bar.
+
+    Click :octicons-three-bars-16: (top left) on mobile.
+
 # Welcome
 
 Welcome to the [Choreo](https://github.com/SleipnirGroup/Choreo) documentation.


### PR DESCRIPTION
Hides the TOC and navigation from `index.html` home page. This allows the 3 cards under `What is Choreo` header. Changes it from this:

![image](https://github.com/SleipnirGroup/Choreo/assets/70717139/39a48e98-295c-4229-9048-15b83f8e3d74)


to:

![36581](https://github.com/SleipnirGroup/Choreo/assets/70717139/8bd8aadc-0490-4f98-9491-007461e38d3a)
