### PR TITLE
Docs/navigation

### DIFF
--- a/docs/contributing/contributing-guide.md
+++ b/docs/contributing/contributing-guide.md
@@ -2,13 +2,6 @@
 
 Thank you for your interest in contributing to this project! We appreciate your help in making it better.
 
-## Table of Contents
-- [Introduction](#introduction)
-- [Submitting Issues](#submitting-issues)
-- [Pull Requests](#pull-requests)
-- [Code Style](#code-style)
-- [License](#license)
-
 ## Introduction
 
 This document outlines the guidelines for contributing to this project. It covers submitting issues, creating pull requests, and maintaining code quality.

--- a/docs/document-settings.md
+++ b/docs/document-settings.md
@@ -2,6 +2,7 @@
 
 The Document Settings panel allows you to configure several document-wide settings. Access the Document Settings panel
 by clicking "Document Settings" in Choreo's main menu. 
+
 ![Document Settings option in the main menu](./media/document-settings-menu.png)
 
 See the pages below for explanations of each tab in the Document Settings panel.

--- a/docs/document-settings.md
+++ b/docs/document-settings.md
@@ -7,6 +7,6 @@ by clicking "Document Settings" in Choreo's main menu.
 
 See the pages below for explanations of each tab in the Document Settings panel.
 
-[Robot Configuration](./document-settings/robot-configuration/)
+[Robot Configuration](./document-settings/robot-configuration.md)
 
-[File Export Settings](./document-settings/file-export-settings)
+[File Export Settings](./document-settings/file-export-settings.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,6 @@ hide:
   - toc
 ---
 
-!!! tip inline end
-
-    See the navigation links in the header or side-bar.
-
-    Click :octicons-three-bars-16: (top left) on mobile.
-
 # Welcome
 
 Welcome to the [Choreo](https://github.com/SleipnirGroup/Choreo) documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
----
-hide:
-  - toc
----
-
 # Welcome
 
 Welcome to the [Choreo](https://github.com/SleipnirGroup/Choreo) documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,15 @@
+---
+hide:
+  - toc
+  - navigation
+---
+
+!!! tip inline end
+
+    See the navigation links in the header or side-bar.
+
+    Click :octicons-three-bars-16: (top left) on mobile.
+
 # Welcome
 
 Welcome to the [Choreo](https://github.com/SleipnirGroup/Choreo) documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 hide:
   - toc
-  - navigation
 ---
 
 !!! tip inline end

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,4 +16,4 @@ Start by downloading Choreo from **[Releases](https://github.com/SleipnirGroup/C
 
 Checkout [Building Choreo](./contributing/building-choreo.md) for instruction on how to build Choreo as well as the tech stack.
 
-## Once installed, head to [Robot Config](./document-settings/robot-configuration.md) to configure Choreo for your robot.
+Once installed, head to [Robot Config](./document-settings/robot-configuration.md) to configure Choreo for your robot.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
     - search.suggest
     - announce.dismiss
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.top
     - navigation.instant
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ theme:
     - content.code.annotate
     - content.code.select.title
     - toc.follow
+    - toc.integrate
     - content.tabs.link
     - search.share
     - search.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,6 @@ theme:
     - navigation.tabs
     - navigation.top
     - navigation.instant
-    - navigation.indexes
 
 # Extensions
 markdown_extensions:
@@ -83,10 +82,9 @@ nav:
   - Home:
       - Home: index.md
       - Installation: installation.md
-      - Document Settings:
-          - Document Settings Panel: document-settings.md
-          - Robot Configuration: document-settings/robot-configuration.md
-          - File Export Settings: document-settings/file-export-settings.md
+      - Document Settings Panel: document-settings.md
+      - Robot Configuration: document-settings/robot-configuration.md
+      - File Export Settings: document-settings/file-export-settings.md
   - Usage:
       - Editing Paths: usage/editing-paths.md
       - Controls & Shortcuts: usage/controls-shortcuts.md


### PR DESCRIPTION
The theme of this PR is: 
Navigation should always feel and behave the same no matter where you are on the site

- Integrated the TOC so it's inline with the navigation. This closes #254 
    - This also supersedes #298  since the TOC is always integrated into the nav
- Removed the navigation tip from the main page
    - The _hope_ is that the navigation is now so clear, users don't need extra help to navigate the site
- Clean up some headers that showed up in the TOC/nav unexpectedly
- Flattened the nav hierarchy so that the Document Settings Panel, Robot Configuration, and File Export Settings pages are not under a subfolder and instead are seen right away on the Home page navigation.
- Made the nav area sticky