### PR TITLE
Remove extra console logs and distracting zoom-fit

### DIFF
--- a/src/components/field/svg/FieldOverlayRoot.tsx
+++ b/src/components/field/svg/FieldOverlayRoot.tsx
@@ -67,8 +67,6 @@ class FieldOverlayRoot extends Component<Props, State> {
     window.addEventListener("resize", () => this.handleResize());
 
     window.addEventListener("center", (e) => {
-      console.log(`Centering on ${e}`);
-      console.log(`current zoom level: ${this.state.zoom}`);
       this.center(
         (e as CustomEvent).detail.x,
         (e as CustomEvent).detail.y,
@@ -125,8 +123,6 @@ class FieldOverlayRoot extends Component<Props, State> {
     return 0;
   }
   handleResize() {
-    console.log(`current zoom level: ${this.state.zoom}`);
-
     const factor = this.getScalingFactor(this.svgRef?.current);
     this.context.model.uiState.setFieldScalingFactor(factor);
   }

--- a/src/components/sidebar/PathSelector.tsx
+++ b/src/components/sidebar/PathSelector.tsx
@@ -95,7 +95,6 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
     const selected =
       this.props.uuid == this.context.model.document.pathlist.activePathUUID;
     const name = this.getPath().name;
-    this.context.model.zoomToFitWaypoints();
     if (name != this.state.name && !this.state.renaming) {
       this.state.name = name;
     }


### PR DESCRIPTION
zoomToFitWaypoints() ran on every rerender of the path selector, including start and end of every generation.