### PR TITLE
Add getFlippedInitialPose() and getFlippedFinalPose() to ChoreoTrajectory

### DIFF
--- a/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectory.java
+++ b/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectory.java
@@ -118,12 +118,30 @@ public class ChoreoTrajectory {
   }
 
   /**
+   * Returns the initial, mirrored pose of the trajectory.
+   *
+   * @return the initial, mirrored pose of the trajectory.
+   */
+  public Pose2d getFlippedInitialPose() {
+    return samples.get(0).flipped().getPose();
+  }
+
+  /**
    * Returns the final, non-mirrored pose of the trajectory.
    *
    * @return the final, non-mirrored pose of the trajectory.
    */
   public Pose2d getFinalPose() {
     return samples.get(samples.size() - 1).getPose();
+  }
+
+  /**
+   * Returns the final, mirrored pose of the trajectory.
+   *
+   * @return the final, mirrored pose of the trajectory.
+   */
+  public Pose2d getFlippedFinalPose() {
+    return samples.get(samples.size() - 1).flipped().getPose();
   }
 
   /**

--- a/choreolib/src/main/native/cpp/choreo/lib/ChoreoTrajectory.cpp
+++ b/choreolib/src/main/native/cpp/choreo/lib/ChoreoTrajectory.cpp
@@ -59,8 +59,16 @@ frc::Pose2d ChoreoTrajectory::GetInitialPose() const {
   return samples.front().GetPose();
 }
 
+frc::Pose2d ChoreoTrajectory::GetFlippedInitialPose() const {
+  return samples.front().Flipped().GetPose();
+}
+
 frc::Pose2d ChoreoTrajectory::GetFinalPose() const {
   return samples.back().GetPose();
+}
+
+frc::Pose2d ChoreoTrajectory::GetFlippedFinalPose() const {
+  return samples.back().Flipped().GetPose();
 }
 
 units::second_t ChoreoTrajectory::GetTotalTime() const {

--- a/choreolib/src/main/native/include/choreo/lib/ChoreoTrajectory.h
+++ b/choreolib/src/main/native/include/choreo/lib/ChoreoTrajectory.h
@@ -34,20 +34,32 @@ class ChoreoTrajectory {
                                bool mirrorForRedAlliance = false);
 
   /**
-   * Returns the first pose in the list of samples of the trajectory (t=0)
+   * Returns the initial, non-mirrored pose of the trajectory.
    *
-   * @return the first pose in the list of samples of the trajectory (t=0)
+   * @return the initial, non-mirrored pose of the trajectory.
    */
   frc::Pose2d GetInitialPose() const;
 
   /**
-   * Returns the last pose in the list of samples of the trajectory
-   *  (t=GetTotalTime())
+   * Returns the initial, mirrored pose of the trajectory.
    *
-   * @return the last pose in the list of samples of the trajectory
-   *  (t=GetTotalTime())
+   * @return the initial, mirrored pose of the trajectory.
+   */
+  frc::Pose2d GetFlippedInitialPose() const;
+
+  /**
+   * Returns the final, non-mirrored pose of the trajectory.
+   *
+   * @return the final, non-mirrored pose of the trajectory.
    */
   frc::Pose2d GetFinalPose() const;
+
+  /**
+   * Returns the final, mirrored pose of the trajectory.
+   *
+   * @return the final, mirrored pose of the trajectory.
+   */
+  frc::Pose2d GetFlippedFinalPose() const;
 
   /**
    * Returns the total run time of the trajectory


### PR DESCRIPTION
Addresses #390 and adds getters for the flipped initial and final poses.