### PR TITLE
Allow markers with missing targets to be deserialized

### DIFF
--- a/src/document/EventMarkerStore.tsx
+++ b/src/document/EventMarkerStore.tsx
@@ -145,7 +145,7 @@ export interface ICommandStore extends Instance<typeof CommandStore> {}
 export const EventMarkerStore = types
   .model("EventMarker", {
     name: types.string,
-    target: WaypointScope,
+    target: types.maybe(WaypointScope),
     trajTargetIndex: types.maybe(types.number),
     offset: types.number,
     command: CommandStore,


### PR DESCRIPTION
Affects file opening and path duplication (since duplication serializes and deserializes a path into a copy).

This works by allowing `undefined` as a marker target on marker creation.

Known issue/potential unwanted behavior: Once the marker is retargeted on the duplicate, its **!** message will say "marker added since last generation!" if the previous trajectory was stale when duplicated.
