### PR TITLE
Change artifact path of aarch64 windows installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         run: mv *.exe Choreo-${{ github.ref_name }}-Windows-x86_64.exe
 
       - name: Rename Windows aarch64 bundle
-        working-directory: pkg/Windows-aarch64/release/bundle/nsis
+        working-directory: pkg/Windows-aarch64/aarch64-pc-windows-msvc/release/bundle/nsis
         run: mv *.exe Choreo-${{ github.ref_name }}-Windows-aarch64.exe
 
       - name: Rename macOS x86_64 bundle


### PR DESCRIPTION
See the path used here: https://github.com/SleipnirGroup/Choreo/actions/runs/8427814991/job/23079514897#step:3:44
and how the CI subsequently fails by using the wrong working directory for renaming the aarch64 installer.