### PR TITLE
Add Git and version numbers to build requirements

### DIFF
--- a/docs/contributing/building-choreo.md
+++ b/docs/contributing/building-choreo.md
@@ -2,18 +2,18 @@
 
 ### Requirements for Windows
 
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install), [CMake](https://cmake.org/download)
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install) ≥ 1.70.0, [CMake](https://cmake.org/download) ≥ 3.24, [Git](https://git-scm.com/)
 - [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/) with C++ programming language selected during installation
 
 ### Requirements for macOS
 
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install), [CMake](https://cmake.org/download)
-- Xcode command-line tools via `xcode-select --install`
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install) ≥ 1.70.0, [CMake](https://cmake.org/download) ≥ 3.24, [Git](https://git-scm.com/)
+- Xcode ≥ 15.0.1 command-line tools via `xcode-select --install`
 
 ### Requirements for Linux
 
-- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install), [CMake](https://cmake.org/download)
-- GCC via `sudo apt install gcc`
+- [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), [Rust](https://www.rust-lang.org/tools/install) ≥ 1.70.0, [CMake](https://cmake.org/download) ≥ 3.24, [Git](https://git-scm.com/)
+- GCC ≥ 11 via `sudo apt install gcc`
 - Tauri dependencies (see [here](https://tauri.app/v1/guides/getting-started/prerequisites/#setting-up-linux)).
 
 ## Recommended IDE for Tauri


### PR DESCRIPTION
I found the minimum Rust version via `cargo msrv`.