### PR TITLE
apply angle modulus to initial guess dtheta

### DIFF
--- a/src/document/HolonomicPathStore.ts
+++ b/src/document/HolonomicPathStore.ts
@@ -783,9 +783,9 @@ export const HolonomicPathStore = types
       guessControlIntervalCount(i: number, robotConfig: IRobotConfigStore) {
         const dx = self.waypoints.at(i + 1)!.x - self.waypoints.at(i)!.x;
         const dy = self.waypoints.at(i + 1)!.y - self.waypoints.at(i)!.y;
-        const dtheta =
-          self.waypoints.at(i + 1)!.heading - self.waypoints.at(i)!.heading;
-        const headingWeight = 0.5; // arbitrary
+        const dtheta = angleModulus(
+          self.waypoints.at(i + 1)!.heading - self.waypoints.at(i)!.heading);
+        const headingWeight = 0.5 // arbitrary
         const distance = Math.sqrt(dx * dx + dy * dy);
         const maxForce = robotConfig.wheelMaxTorque / robotConfig.wheelRadius;
         const maxAccel = (maxForce * 4) / robotConfig.mass; // times 4 for 4 modules


### PR DESCRIPTION
normalizes the range of dtheta to -pi,pi. Now, the number of guess points added due to a rotation from 5pi/6 to -5pi/6 is the same as a rotation from 0 to 2pi/6.