### PR TITLE
Enhanced ChoreoLib with Time-Based Start and Nearest Trajectory State Functionality

### DIFF
--- a/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectoryState.java
+++ b/choreolib/src/main/java/com/choreo/lib/ChoreoTrajectoryState.java
@@ -45,7 +45,7 @@ public class ChoreoTrajectoryState implements Interpolatable<ChoreoTrajectorySta
    * @param y The Y position of the state in meters.
    * @param heading The heading of the state in radians, with 0 being in the +X direction.
    * @param velocityX The velocity of the state in the X direction in m/s.
-   * @param velocityY The velocity of the state in the X direction in m/s.
+   * @param velocityY The velocity of the state in the Y direction in m/s.
    * @param angularVelocity The angular velocity of the state in rad/s.
    */
   public ChoreoTrajectoryState(

--- a/docs/choreolib/usage.md
+++ b/docs/choreolib/usage.md
@@ -15,8 +15,9 @@ Choreo.choreoSwerveCommand(
     () -> {
         Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
         mirror = alliance.isPresent() && alliance.get() == Alliance.Red;
-    }, // (9)
-    this // (10)
+    }, // (9),
+    5.2 (10),
+    this // (11)
 );
 ```
 
@@ -29,4 +30,5 @@ Choreo.choreoSwerveCommand(
 7. PID constants to correct for rotation error.
 8. A function that consumes the target robot-relative chassis speeds and commands them to the robot.
 9. If this returns true, the path will be mirrored based on alliance (this assumes the path is created for the blue alliance).
-10. The subsystem(s) to require, typically your drive subsystem (this).
+10. The time in the trajectory file at which to start following the path (optional).
+11. The subsystem(s) to require, typically your drive subsystem (this).


### PR DESCRIPTION
> Features:

**Enhancement:** 

- Added functionality to initiate the choreoSwerveCommand from a specific point of time within the trajectory.

**Use Case:** 
Allows the robot to resume following a path from a designated point, useful for scenarios like interrupting the command during autonomous to perform a task (e.g., picking up a game piece with vision) and then seamlessly continuing along the trajectory.

**New Feature:** 

- Implemented the capability to identify the nearest ChoreoTrajectoryState from a given list of trajectories, akin to Pose2d.nearest().

**Explanation:** It is similar to Pose2d.nearest(). The difference is that ChoreoTrajectoryState.nearest() incorporates weighted parameters to determine the impact of errors in each parameter on the output.

**Example Use Case:** Enables the robot, after deviating from the trajectory to perform a task, to resume following the path from the point closest to its current position. The weighting parameters allow fine-tuning of the selection criteria based on specific requirements, such as prioritizing position accuracy.