### PR TITLE
Move copy and open directory buttons in menu to stable position.

### DIFF
--- a/src/AppMenu.tsx
+++ b/src/AppMenu.tsx
@@ -262,16 +262,26 @@ class AppMenu extends Component<Props, State> {
               >
                 {this.context.model.uiState.hasSaveLocation ? (
                   <>
-                    Project saved at<br></br>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center"
+                      }}
+                    >
+                      <span>Project saved at</span>
+                      <span>
+                        <this.CopyToClipboardButton
+                          data={this.projectLocation(false)}
+                          tooltip="Copy full path to clipboard"
+                        ></this.CopyToClipboardButton>
+                        <this.OpenInFilesApp
+                          dir={this.projectLocation(false)}
+                        ></this.OpenInFilesApp>
+                      </span>
+                    </div>
                     <div style={{ fontSize: "0.9em", color: "#D3D3D3" }}>
                       {this.projectLocation(true)}
-                      <this.CopyToClipboardButton
-                        data={this.projectLocation(false)}
-                        tooltip="Copy full path to clipboard"
-                      ></this.CopyToClipboardButton>
-                      <this.OpenInFilesApp
-                        dir={this.projectLocation(false)}
-                      ></this.OpenInFilesApp>
                     </div>
                     <br></br>
                     {this.context.model.uiState.isGradleProject
@@ -282,16 +292,26 @@ class AppMenu extends Component<Props, State> {
                     <div></div>
                     {this.context.model.uiState.hasSaveLocation ? (
                       <>
-                        Trajectories saved in<br></br>
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center"
+                          }}
+                        >
+                          <span>Trajectories saved in</span>
+                          <span>
+                            <this.CopyToClipboardButton
+                              data={this.trajectoriesLocation(false)}
+                              tooltip="Copy full path to clipboard"
+                            ></this.CopyToClipboardButton>
+                            <this.OpenInFilesApp
+                              dir={this.trajectoriesLocation(false)}
+                            ></this.OpenInFilesApp>
+                          </span>
+                        </div>
                         <div style={{ fontSize: "0.9em", color: "#D3D3D3" }}>
                           {this.trajectoriesLocation(true)}
-                          <this.CopyToClipboardButton
-                            data={this.trajectoriesLocation(false)}
-                            tooltip="Copy full path to clipboard"
-                          ></this.CopyToClipboardButton>
-                          <this.OpenInFilesApp
-                            dir={this.trajectoriesLocation(false)}
-                          ></this.OpenInFilesApp>
                         </div>
                       </>
                     ) : (


### PR DESCRIPTION
Before: The button positions depend on the length of the directory path and wrap awkwardly.
![image](https://github.com/SleipnirGroup/Choreo/assets/32416547/6889e8f6-80f9-4738-b63c-b07778fd7648)

After: The button positions are fixed and not dependent on the filepath.
![image](https://github.com/SleipnirGroup/Choreo/assets/32416547/639eba02-5b44-4282-95e5-886892526663)
