### PR TITLE
Improve handling of sidebar and navbar selection being undefined/-1

### DIFF
--- a/src/components/field/Field.tsx
+++ b/src/components/field/Field.tsx
@@ -33,10 +33,14 @@ export class Field extends Component<Props, State> {
     const selectedSidebar = this.context.model.uiState.selectedSidebarItem;
     const activePath = this.context.model.document.pathlist.activePath;
     const activePathUUID = this.context.model.document.pathlist.activePathUUID;
-    const indexIfWaypoint = activePath.waypoints.findIndex(
-      (point: IHolonomicWaypointStore) =>
-        point.uuid == (selectedSidebar as IHolonomicWaypointStore)!.uuid
-    );
+    let indexIfWaypoint = -1;
+    if (selectedSidebar !== undefined && "heading" in selectedSidebar) {
+      indexIfWaypoint = activePath.waypoints.findIndex(
+        (point: IHolonomicWaypointStore) =>
+          point.uuid == (selectedSidebar as IHolonomicWaypointStore)?.uuid
+      );
+    }
+
     return (
       <div className={styles.Container}>
         <FieldOverlayRoot></FieldOverlayRoot>

--- a/src/components/field/svg/FieldOverlayRoot.tsx
+++ b/src/components/field/svg/FieldOverlayRoot.tsx
@@ -392,6 +392,16 @@ class FieldOverlayRoot extends Component<Props, State> {
   }
 
   createWaypoint(e: MouseEvent, waypointType: number): void {
+    if (
+      ![
+        NavbarLabels.FullWaypoint,
+        NavbarLabels.TranslationWaypoint,
+        NavbarLabels.EmptyWaypoint,
+        NavbarLabels.InitialGuessPoint
+      ].includes(waypointType)
+    ) {
+      return;
+    }
     const coords = this.screenSpaceToFieldSpace(this.svgRef?.current, {
       x: e.clientX,
       y: e.clientY

--- a/src/document/CircularObstacleStore.tsx
+++ b/src/document/CircularObstacleStore.tsx
@@ -24,7 +24,7 @@ export const CircularObstacleStore = types
         return false;
       }
       return (
-        self.uuid ==
+        self.uuid ===
         safeGetIdentifier(
           getRoot<IStateStore>(self).uiState.selectedSidebarItem
         )

--- a/src/document/ConstraintStore.tsx
+++ b/src/document/ConstraintStore.tsx
@@ -196,7 +196,7 @@ export const ConstraintStore = types
         return false;
       }
       return (
-        self.uuid ==
+        self.uuid ===
         safeGetIdentifier(
           getRoot<IStateStore>(self).uiState.selectedSidebarItem
         )

--- a/src/document/EventMarkerStore.tsx
+++ b/src/document/EventMarkerStore.tsx
@@ -157,7 +157,7 @@ export const EventMarkerStore = types
         return false;
       }
       return (
-        self.uuid ==
+        self.uuid ===
         safeGetIdentifier(
           getRoot<IStateStore>(self).uiState.selectedSidebarItem
         )

--- a/src/document/HolonomicWaypointStore.ts
+++ b/src/document/HolonomicWaypointStore.ts
@@ -36,7 +36,7 @@ export const HolonomicWaypointStore = types
           return false;
         }
         return (
-          self.uuid ==
+          self.uuid ===
           safeGetIdentifier(
             getRoot<IStateStore>(self).uiState.selectedSidebarItem
           )


### PR DESCRIPTION
Other uses of selectedSidebarItem were guarded behind undefined-checks already. Note that `safeGetIdentifier` returns `undefined` if the input is `undefined`, so the equality checks were made triple-equals for better comparison safety.