### PR TITLE
Update macOS deployment target to 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 12
+      MACOSX_DEPLOYMENT_TARGET: 13
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/choreolib.yml
+++ b/.github/workflows/choreolib.yml
@@ -61,7 +61,7 @@ jobs:
 
   build-host:
     env:
-      MACOSX_DEPLOYMENT_TARGET: 12
+      MACOSX_DEPLOYMENT_TARGET: 13
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
macOS 12 will hit EOL later this year.