### PR TITLE
[choreo] short circuit add constraint layer for constraints with only waypoint scopes

### DIFF
--- a/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
+++ b/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
@@ -1,5 +1,6 @@
 import { Component } from "react";
 import { doc, uiState } from "../../../../document/DocumentManager";
+import { ConstraintDefinitions } from "../../../../document/ConstraintDefinitions";
 
 import { observer } from "mobx-react";
 import FieldConstraintRangeLayer from "./FieldConstraintRangeLayer";
@@ -87,8 +88,7 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
           onCircleClick={(id) => {
             console.log("constraint from: ", id);
             const constraintToAdd = uiState.getSelectedConstraintKey();
-            console.log("constraint to add key: ", constraintToAdd);
-            if (constraintToAdd == "StopPoint") {
+            if (!ConstraintDefinitions[constraintToAdd].sgmtScope) {
               this.addConstraint(waypoints, id, undefined);
             } else {
               this.setState({ firstIndex: id });

--- a/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
+++ b/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
@@ -20,15 +20,16 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
     super(props);
   }
 
-  addConstraint(points: IHolonomicWaypointStore[], start: number, end: number) {
+  addConstraint(points: IHolonomicWaypointStore[], start: number, end?: number) {
+    doc.setHoveredSidebarItem(undefined);
     doc.history.startGroup(() => {
       const constraintToAdd = uiState.getSelectedConstraintKey();
       const point1 = points[start];
-      const point2 = points[end];
+      const point2 = (end !== undefined) ? points[end] : undefined;
       const newConstraint = doc.pathlist.activePath.path.addConstraint(
         constraintToAdd,
         { uuid: point1.uuid },
-        { uuid: point2.uuid }
+        point2 !== undefined ? { uuid: point2.uuid } : undefined
       );
 
       if (newConstraint !== undefined) {
@@ -36,6 +37,7 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
       }
       doc.history.stopGroup();
     });
+    this.setState({ firstIndex: undefined });
   }
 
   get endIndex() {
@@ -63,6 +65,8 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
     }
     return undefined;
   }
+
+
   render() {
     const lineColor = this.props.lineColor ?? "white";
     const activePath = doc.pathlist.activePath;
@@ -79,7 +83,17 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
           id="add-first-circles"
           onCircleClick={(id) => {
             console.log("constraint from: ", id);
-            this.setState({ firstIndex: id });
+            const constraintToAdd = uiState.getSelectedConstraintKey();
+            console.log("constraint to add key: ", constraintToAdd);
+            if (constraintToAdd == "StopPoint") {
+              this.addConstraint(
+                waypoints,
+                id,
+                undefined
+              );
+            } else {
+              this.setState({ firstIndex: id });
+            }
           }}
         ></FieldConstraintRangeLayer>
       );
@@ -137,13 +151,11 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
             showLines={false}
             id="add-second-circles"
             onCircleClick={(id) => {
-              doc.setHoveredSidebarItem(undefined);
               this.addConstraint(
                 waypoints,
                 Math.min(this.state.firstIndex!, id),
                 Math.max(this.state.firstIndex!, id)
               );
-              this.setState({ firstIndex: undefined });
             }}
             onCircleMouseOver={(id) => doc.setHoveredSidebarItem(waypoints[id])}
             onCircleMouseOff={(id) => doc.setHoveredSidebarItem(undefined)}

--- a/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
+++ b/src/components/field/svg/constraintDisplay/FieldConstraintAddLayer.tsx
@@ -20,12 +20,16 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
     super(props);
   }
 
-  addConstraint(points: IHolonomicWaypointStore[], start: number, end?: number) {
+  addConstraint(
+    points: IHolonomicWaypointStore[],
+    start: number,
+    end?: number
+  ) {
     doc.setHoveredSidebarItem(undefined);
     doc.history.startGroup(() => {
       const constraintToAdd = uiState.getSelectedConstraintKey();
       const point1 = points[start];
-      const point2 = (end !== undefined) ? points[end] : undefined;
+      const point2 = end !== undefined ? points[end] : undefined;
       const newConstraint = doc.pathlist.activePath.path.addConstraint(
         constraintToAdd,
         { uuid: point1.uuid },
@@ -66,7 +70,6 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
     return undefined;
   }
 
-
   render() {
     const lineColor = this.props.lineColor ?? "white";
     const activePath = doc.pathlist.activePath;
@@ -86,11 +89,7 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
             const constraintToAdd = uiState.getSelectedConstraintKey();
             console.log("constraint to add key: ", constraintToAdd);
             if (constraintToAdd == "StopPoint") {
-              this.addConstraint(
-                waypoints,
-                id,
-                undefined
-              );
+              this.addConstraint(waypoints, id, undefined);
             } else {
               this.setState({ firstIndex: id });
             }


### PR DESCRIPTION
stop points (and future waypoint-only constraints) should only be added to a single waypoint. this adjusts the constraint adding UI so that adding a stop point is completed after clicking a single waypoint.