### PR TITLE
[ci] Shorten recursive wildcard

### DIFF
--- a/.github/workflows/choreo.yml
+++ b/.github/workflows/choreo.yml
@@ -82,14 +82,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: target/**/release/bundle/nsis/*.exe
+          path: "**/*.exe"
 
       - name: Upload bundle (macOS)
         if: startsWith(matrix.os, 'macOS')
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: target/**/release/bundle/dmg/*.dmg
+          path: "**/*.dmg"
 
       - name: Upload bundle (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -97,8 +97,8 @@ jobs:
         with:
           name: ${{ matrix.artifact-name }}
           path: |
-            target/**/release/bundle/appimage/*.AppImage
-            target/**/release/bundle/deb/*.deb
+            **/*.AppImage
+            **/*.deb
 
   release:
     name: Create draft release
@@ -118,27 +118,27 @@ jobs:
         run: ls -R
 
       - name: Rename Windows x86_64 bundle
-        working-directory: pkg/Windows-x86_64/release/bundle/nsis
+        working-directory: pkg/Windows-x86_64
         run: mv *.exe Choreo-${{ github.ref_name }}-Windows-x86_64.exe
 
       - name: Rename Windows aarch64 bundle
-        working-directory: pkg/Windows-aarch64/aarch64-pc-windows-msvc/release/bundle/nsis
+        working-directory: pkg/Windows-aarch64
         run: mv *.exe Choreo-${{ github.ref_name }}-Windows-aarch64.exe
 
       - name: Rename macOS x86_64 bundle
-        working-directory: pkg/macOS-x86_64/x86_64-apple-darwin/release/bundle/dmg
+        working-directory: pkg/macOS-x86_64
         run: mv *.dmg Choreo-${{ github.ref_name }}-macOS-x86_64.dmg
 
       - name: Rename macOS arm64 bundle
-        working-directory: pkg/macOS-arm64/aarch64-apple-darwin/release/bundle/dmg
+        working-directory: pkg/macOS-arm64
         run: mv *.dmg Choreo-${{ github.ref_name }}-macOS-arm64.dmg
 
       - name: Rename Linux x86_64 file (.AppImage)
-        working-directory: pkg/Linux-x86_64/release/bundle/appimage
+        working-directory: pkg/Linux-x86_64
         run: mv *.AppImage Choreo-${{ github.ref_name }}-Linux-x86_64.AppImage
 
       - name: Rename Linux x86_64 file (.deb)
-        working-directory: pkg/Linux-x86_64/release/bundle/deb
+        working-directory: pkg/Linux-x86_64
         run: mv *.deb Choreo-${{ github.ref_name }}-Linux-x86_64.deb
 
       - name: Display structure of renamed files


### PR DESCRIPTION
Tauri always puts the installer in the same location everytime. Removing the wildcard means the zip file can contain just the installer with no extra directories.