### PR TITLE
[ci] Hardcode all paths to installers

### DIFF
--- a/.github/workflows/choreo.yml
+++ b/.github/workflows/choreo.yml
@@ -77,28 +77,42 @@ jobs:
       - name: Build package
         run: pnpm run tauri build ${{ matrix.tauri-build-flags }}
 
-      - name: Upload bundle (Windows)
-        if: startsWith(matrix.os, 'windows')
+      - name: Upload bundle (Windows x86)
+        if: matrix.artifact-name == 'Windows-x86_64'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: "**/*.exe"
+          path: target/release/bundle/nsis/*.exe
 
-      - name: Upload bundle (macOS)
-        if: startsWith(matrix.os, 'macOS')
+      - name: Upload bundle (Windows ARM)
+        if: matrix.artifact-name == 'Windows-aarch64'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
-          path: "**/*.dmg"
+          path: target/aarch64-pc-windows-msvc/release/bundle/nsis/*.exe
+
+      - name: Upload bundle (macOS x86)
+        if: matrix.artifact-name == 'macOS-x86_64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+
+      - name: Upload bundle (macOS ARM)
+        if: matrix.artifact-name == 'macOS-arm64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
 
       - name: Upload bundle (Linux)
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.artifact-name == 'Linux-x86_64'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}
           path: |
-            **/*.AppImage
-            **/*.deb
+            target/release/bundle/appimage/*.AppImage
+            target/release/bundle/deb/*.deb
 
   release:
     name: Create draft release

--- a/.github/workflows/choreo.yml
+++ b/.github/workflows/choreo.yml
@@ -148,11 +148,11 @@ jobs:
         run: mv *.dmg Choreo-${{ github.ref_name }}-macOS-arm64.dmg
 
       - name: Rename Linux x86_64 file (.AppImage)
-        working-directory: pkg/Linux-x86_64
+        working-directory: pkg/Linux-x86_64/appimage
         run: mv *.AppImage Choreo-${{ github.ref_name }}-Linux-x86_64.AppImage
 
       - name: Rename Linux x86_64 file (.deb)
-        working-directory: pkg/Linux-x86_64
+        working-directory: pkg/Linux-x86_64/deb
         run: mv *.deb Choreo-${{ github.ref_name }}-Linux-x86_64.deb
 
       - name: Display structure of renamed files


### PR DESCRIPTION
[Since path hierarchies are preserved after the first wildcard](https://github.com/actions/upload-artifact/?tab=readme-ov-file#upload-using-multiple-paths-and-exclusions), the paths to the installer files have been hardcoded, leaving only the installer file name as a wildcard.