### PR TITLE
[ci] Fix TrajoptLib tests failing on Windows

### DIFF
--- a/.github/workflows/trajoptlib-cpp.yml
+++ b/.github/workflows/trajoptlib-cpp.yml
@@ -14,11 +14,9 @@ jobs:
       matrix:
         include:
           - artifact-name: Windows x86_64
-            # FIXME: Tests give "Exit code 0xc0000135" for missing DLLs
-            cmake-args: "-DCMAKE_GENERATOR_PLATFORM=x64 -DBUILD_TESTING=OFF"
+            cmake-args: "-DCMAKE_GENERATOR_PLATFORM=x64"
             os: windows-2022
           - artifact-name: Windows aarch64
-            # FIXME: Tests give "Exit code 0xc0000135" for missing DLLs
             cmake-args: "-DCMAKE_GENERATOR_PLATFORM=ARM64 -DBUILD_TESTING=OFF"
             os: windows-2022
           - artifact-name: macOS universal
@@ -58,7 +56,7 @@ jobs:
       - run: cmake --preset with-examples ${{ matrix.cmake-args }}
         if: ${{ !startsWith(matrix.os, 'windows') }}
         working-directory: trajoptlib
-      - run: cmake -B build -S . -DWITH_EXAMPLES=ON ${{ matrix.cmake-args }}
+      - run: cmake -B build -S . -DBUILD_EXAMPLES=ON ${{ matrix.cmake-args }}
         if: startsWith(matrix.os, 'windows')
         working-directory: trajoptlib
       - run: cmake --build build --config RelWithDebInfo --parallel 4

--- a/trajoptlib/CMakeLists.txt
+++ b/trajoptlib/CMakeLists.txt
@@ -9,7 +9,7 @@ FATAL: In-source builds are not allowed.
     )
 endif()
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.22)
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
@@ -166,7 +166,7 @@ if(BUILD_TESTING)
     list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
     include(Catch)
 endif()
-
+get_cmake_property(IS_MULTI_CONFIG GENERATOR_IS_MULTI_CONFIG)
 # Build TrajoptLib tests
 if(BUILD_TESTING)
     file(GLOB_RECURSE TrajoptLib_test_src test/src/*.cpp)
@@ -184,7 +184,11 @@ if(BUILD_TESTING)
     )
     if(NOT CMAKE_TOOLCHAIN_FILE)
         # https://github.com/catchorg/Catch2/issues/2873
-        catch_discover_tests(TrajoptLibTest PROPERTIES SKIP_RETURN_CODE 4)
+        catch_discover_tests(
+            TrajoptLibTest
+            PROPERTIES SKIP_RETURN_CODE 4
+            DL_PATHS ${Sleipnir_BINARY_DIR}/$<${IS_MULTI_CONFIG}:$<CONFIG>>
+        )
     endif()
 endif()
 
@@ -228,7 +232,12 @@ if(BUILD_EXAMPLES)
             )
             if(NOT CMAKE_TOOLCHAIN_FILE)
                 # https://github.com/catchorg/Catch2/issues/2873
-                catch_discover_tests(${example}Test PROPERTIES SKIP_RETURN_CODE 4)
+                catch_discover_tests(
+                    ${example}Test
+                    PROPERTIES SKIP_RETURN_CODE 4
+                    DL_PATHS
+                        ${Sleipnir_BINARY_DIR}/$<${IS_MULTI_CONFIG}:$<CONFIG>>
+                )
             endif()
         endif()
     endforeach()

--- a/trajoptlib/test/src/geometry/Translation2dTest.cpp
+++ b/trajoptlib/test/src/geometry/Translation2dTest.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Translation2d - Polar constructor", "[Translation2d]") {
   trajopt::Translation2d one{std::numbers::sqrt2 * 1.0,
                              trajopt::Rotation2d{std::numbers::pi / 4}};
   CHECK(one.X() == Catch::Approx(1.0).margin(1e-9));
-  CHECK(one.Y() == 1.0);
+  CHECK(one.Y() == Catch::Approx(1.0).margin(1e-9));
 
   trajopt::Translation2d two{2.0, trajopt::Rotation2d{std::numbers::pi / 3}};
   CHECK(two.X() == Catch::Approx(1.0).margin(1e-9));


### PR DESCRIPTION
Adds Sleipnir's build directory to the DLL search paths. [The Catch2 feature](https://github.com/catchorg/Catch2/blob/devel/extras/Catch.cmake#L120) that enabled this fix requires CMake >=3.22 though. I also modified one of tests that was failing on my system.

Fixes #512.