### PR TITLE
[ci] Use pull_request_target event for deleting caches

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,7 +1,7 @@
 # Modifed from https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
 name: Clean up unused caches
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
   workflow_dispatch:


### PR DESCRIPTION
`pull_request` doesn't have the necessary perms, so `pull_request_target` is used instead.