### PR TITLE
Clean up npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.16.7",
     "@tauri-apps/api": "^1.6.0",
-    "@typescript-eslint/parser": "^8.2.0",
-    "ajv": "^8.17.1",
     "d3": "^7.9.0",
     "hotkeys-js": "^3.13.7",
     "mathjs": "^13.0.2",
@@ -45,8 +43,7 @@
     "react": "^18.3.1",
     "@hello-pangea/dnd": "^16.6.0",
     "react-dom": "^18.3.1",
-    "react-toastify": "^10.0.5",
-    "uuid": "^10.0.0"
+    "react-toastify": "^10.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
@@ -55,8 +52,8 @@
     "@types/node": "^22.5.0",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.2.0",
+    "@typescript-eslint/parser": "^8.2.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^9.7.0",
     "eslint-plugin-n": "^17.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,12 +29,6 @@ importers:
       '@tauri-apps/api':
         specifier: ^1.6.0
         version: 1.6.0
-      '@typescript-eslint/parser':
-        specifier: ^8.2.0
-        version: 8.2.0(eslint@9.9.0)(typescript@5.5.4)
-      ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -68,9 +62,6 @@ importers:
       react-toastify:
         specifier: ^10.0.5
         version: 10.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      uuid:
-        specifier: ^10.0.0
-        version: 10.0.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.1.0
@@ -90,12 +81,12 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.2.0
         version: 8.2.0(@typescript-eslint/parser@8.2.0(eslint@9.9.0)(typescript@5.5.4))(eslint@9.9.0)(typescript@5.5.4)
+      '@typescript-eslint/parser':
+        specifier: ^8.2.0
+        version: 8.2.0(eslint@9.9.0)(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.4.2(@types/node@22.5.0))
@@ -878,9 +869,6 @@ packages:
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
 
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
   '@typescript-eslint/eslint-plugin@8.2.0':
     resolution: {integrity: sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -956,9 +944,6 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1438,9 +1423,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.1:
-    resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
-
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -1756,9 +1738,6 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -2061,10 +2040,6 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2293,10 +2268,6 @@ packages:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
 
   vite@5.4.2:
     resolution: {integrity: sha512-dDrQTRHp5C1fTFzcSaMxjk6vdpKvT+2/mIdE07Gw2ykehT49O0z/VHS3zZ8iV/Gh8BJJKHWOe5RjaNrW5xf/GA==}
@@ -3105,8 +3076,6 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.3': {}
 
-  '@types/uuid@10.0.0': {}
-
   '@typescript-eslint/eslint-plugin@8.2.0(@typescript-eslint/parser@8.2.0(eslint@9.9.0)(typescript@5.5.4))(eslint@9.9.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
@@ -3211,13 +3180,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.0.1
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -3872,8 +3834,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.1: {}
-
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -4171,8 +4131,6 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0: {}
-
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
@@ -4455,8 +4413,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  require-from-string@2.0.2: {}
-
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4724,8 +4680,6 @@ snapshots:
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:
       react: 18.3.1
-
-  uuid@10.0.0: {}
 
   vite@5.4.2(@types/node@22.5.0):
     dependencies:

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -1,6 +1,5 @@
 import { dialog, path, window as tauriWindow } from "@tauri-apps/api";
 import { TauriEvent } from "@tauri-apps/api/event";
-import { v4 as uuidv4 } from "uuid";
 import { DocumentStore, SelectableItemTypes } from "./DocumentModel";
 
 import hotkeys from "hotkeys-js";
@@ -136,7 +135,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
         commandIsTime(command) ? command.data.waitTime : 0,
         "Time"
       ),
-      uuid: uuidv4()
+      uuid: crypto.randomUUID()
     });
   }
 
@@ -177,7 +176,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
             y: vars().createExpression(config.modules[i].y, "Length")
           };
         }),
-        identifier: uuidv4()
+        identifier: crypto.randomUUID()
       });
     },
     WaypointStore: (waypoint: Waypoint<Expr>) => {
@@ -186,7 +185,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
         x: vars().createExpression(waypoint.x, "Length"),
         y: vars().createExpression(waypoint.y, "Length"),
         heading: vars().createExpression(waypoint.heading, "Angle"),
-        uuid: uuidv4()
+        uuid: crypto.randomUUID()
       });
     },
     ObstacleStore: (
@@ -198,7 +197,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
         x: vars().createExpression(x, "Length"),
         y: vars().createExpression(y, "Length"),
         radius: vars().createExpression(radius, "Length"),
-        uuid: uuidv4()
+        uuid: crypto.randomUUID()
       });
     },
     CommandStore: createCommandStore,
@@ -209,7 +208,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
         trajTargetIndex: marker.trajTargetIndex,
         offset: vars().createExpression(marker.offset, "Time"),
         command: createCommandStore(marker.command),
-        uuid: uuidv4()
+        uuid: crypto.randomUUID()
       });
     },
     ConstraintData: constraintDataConstructors,
@@ -222,7 +221,7 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
       const store = ConstraintStore.create({
         from,
         to,
-        uuid: uuidv4(),
+        uuid: crypto.randomUUID(),
         //@ts-expect-error more constraint stuff not quite working
         data: constraintDataConstructors[type](data)
       });

--- a/src/document/PathListStore.ts
+++ b/src/document/PathListStore.ts
@@ -1,5 +1,4 @@
 import { Instance, getEnv, types } from "mobx-state-tree";
-import { v4 as uuidv4 } from "uuid";
 import { Traj } from "./2025/DocumentTypes";
 import { Env } from "./DocumentManager";
 import { HolonomicPathStore } from "./path/HolonomicPathStore";
@@ -43,7 +42,7 @@ export const PathListStore = types
         return (
           self.paths.get(self.activePathUUID)! ||
           HolonomicPathStore.create({
-            uuid: uuidv4(),
+            uuid: crypto.randomUUID(),
             name: "New Path",
             params: {
               constraints: [],
@@ -86,7 +85,7 @@ export const PathListStore = types
       },
       addPath(name: string, select: boolean = false, contents?: Traj): string {
         const usedName = this.disambiguateName(name);
-        const newUUID = uuidv4();
+        const newUUID = crypto.randomUUID();
         const env = getEnv<Env>(self);
         env.startGroup(() => {
           try {


### PR DESCRIPTION
ajv stopped being used in #672, uuid was replaced with a built-in, and `@typescript-eslint/parser` is a dev dependency, not an app dependency.