### PR TITLE
[choreo] Add better heading adjustment for zero angular velocity segments

### DIFF
--- a/src-core/src/generation/heading.rs
+++ b/src-core/src/generation/heading.rs
@@ -237,7 +237,7 @@ pub fn calculate_adjusted_headings(traj: &TrajFile) -> ChoreoResult<Vec<f64>> {
                 .enumerate()
                 .for_each(|(i, heading)| {
                     let scalar = (i + 1) as f64 / (idx - last_fixed_heading.0) as f64;
-                    *heading = start + scalar * dtheta;
+                    *heading = angle_modulus(start + scalar * dtheta);
                 });
             last_fixed_heading = (idx, target_heading);
         }

--- a/src-core/src/generation/heading.rs
+++ b/src-core/src/generation/heading.rs
@@ -214,7 +214,7 @@ pub fn calculate_adjusted_headings(traj: &TrajFile) -> ChoreoResult<Vec<f64>> {
     }
 
     // sanity check that fix heading waypoints are not modified
-    if let Some((i, w)) = waypoints
+    if let Some((i, _)) = waypoints
         .iter()
         .enumerate()
         .filter(|(_, w)| w.fix_heading)


### PR DESCRIPTION
-fixes an indexing bug where a zero angular velocity constraint on wpts 3-4 would incorrectly report a heading conflict with a pose on wpt 5.
-adjusts translation and guess waypoint headings that are a part of zero angular velocity segments based on surrounding pose and point at constraints