### PR TITLE
[choreo] update default new project path name to match add path

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -690,7 +690,7 @@ export async function newProject() {
   const newChor = await Commands.defaultProject();
   doc.deserializeChor(newChor);
   uiState.loadPathGradientFromLocalStorage();
-  doc.pathlist.addPath("NewPath");
+  doc.pathlist.addPath("New Path");
   doc.history.clear();
 }
 export function select(item: SelectableItemTypes) {


### PR DESCRIPTION
new projects were created with a single path called "NewPath", and the add path button was using "New Path" (with space).