### PR TITLE
[choreo] use finally instead of then

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -720,7 +720,7 @@ export async function deletePath(uuid: string) {
     const traj = doc.pathlist.paths.get(uuid);
     if (traj) {
       await Commands.deleteTraj(traj.serialize)
-        .then(() => doc.pathlist.deletePath(uuid))
+        .finally(() => doc.pathlist.deletePath(uuid))
         .catch(tracing.error);
     }
   } else {


### PR DESCRIPTION
allows paths without .traj files to be deleted without needing an app restart or to generate a .traj file

needs someone who knows the frontend JS/ts to OK this.

fixes #725 