### PR TITLE
Removes stale indicator, path-wide detail settings, usesDefaultObstacles

### DIFF
--- a/src/components/field/svg/FieldEventMarkerAddLayer.tsx
+++ b/src/components/field/svg/FieldEventMarkerAddLayer.tsx
@@ -31,9 +31,7 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
                 const newMarker = activePath.trajectory.addEventMarker();
 
                 newMarker.setTarget({ uuid: point.uuid });
-                if (!activePath.isTrajectoryStale) {
-                  newMarker.setTrajectoryTargetIndex(index);
-                }
+                // TODO Directly set target index if trajectory not stale
                 doc.setSelectedSidebarItem(newMarker);
               }}
             ></circle>

--- a/src/components/sidebar/PathSelector.tsx
+++ b/src/components/sidebar/PathSelector.tsx
@@ -1,14 +1,7 @@
-import {
-  KeyboardArrowDown,
-  PriorityHigh,
-  Route,
-  Settings
-} from "@mui/icons-material";
+import { Route } from "@mui/icons-material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import {
-  Checkbox,
   CircularProgress,
-  FormControlLabel,
   IconButton,
   TextField,
   Tooltip
@@ -18,8 +11,6 @@ import { observer } from "mobx-react";
 import React, { Component } from "react";
 import { toast } from "react-toastify";
 import { deletePath, doc, renamePath } from "../../document/DocumentManager";
-import Input from "../input/Input";
-import InputList from "../input/InputList";
 import styles from "./Sidebar.module.css";
 
 type Props = object;
@@ -179,7 +170,6 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
           }}
         ></TextField>
         <div>
-
           {/* <Tooltip disableInteractive title="Path Config">
             <IconButton
               className={styles.SidebarRightIcon}

--- a/src/components/sidebar/PathSelector.tsx
+++ b/src/components/sidebar/PathSelector.tsx
@@ -112,18 +112,6 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
             }}
             variant="indeterminate"
           ></CircularProgress>
-        ) : this.getPath().isTrajectoryStale ? (
-          <Tooltip
-            disableInteractive
-            title="Path features no longer match trajectory. Regenerate to be up-to-date."
-          >
-            <PriorityHigh
-              className={styles.SidebarIcon}
-              htmlColor={
-                selected ? "var(--select-yellow)" : "var(--accent-purple)"
-              }
-            ></PriorityHigh>
-          </Tooltip>
         ) : (
           <Route
             className={styles.SidebarIcon}
@@ -191,7 +179,8 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
           }}
         ></TextField>
         <div>
-          <Tooltip disableInteractive title="Path Config">
+
+          {/* <Tooltip disableInteractive title="Path Config">
             <IconButton
               className={styles.SidebarRightIcon}
               onClick={(e) => {
@@ -205,7 +194,7 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
                 <Settings></Settings>
               )}
             </IconButton>
-          </Tooltip>
+          </Tooltip> */}
           <Tooltip disableInteractive title="Delete Path">
             <IconButton
               className={styles.SidebarRightIcon}
@@ -225,52 +214,13 @@ class PathSelectorOption extends Component<OptionProps, OptionState> {
           </Tooltip>
         </div>
         {/* Settings part */}
-        {this.state.settingsOpen && (
+        {/* {this.state.settingsOpen && (
           <>
             <span className={styles.SidebarVerticalLine}></span>
-            <Tooltip
-              disableInteractive
-              title="Estimate needed resolution (# of samples) based on distance between waypoints"
-            >
-              <FormControlLabel
-                sx={{
-                  marginLeft: "0px",
-                  gridColumnStart: 2,
-                  gridColumnEnd: 4
-                }}
-                label="Guess Path Detail"
-                control={
-                  <Checkbox
-                    checked={this.getPath().usesControlIntervalGuessing}
-                    onChange={(e) => {
-                      this.getPath().setControlIntervalGuessing(
-                        e.target.checked
-                      );
-                    }}
-                  />
-                }
-              />
-            </Tooltip>
-            <span className={styles.SidebarVerticalLine}></span>
-            <span style={{ gridColumnStart: 2, gridColumnEnd: 4 }}>
-              <InputList noCheckbox>
-                <Input
-                  title="Default"
-                  suffix="per segment"
-                  showCheckbox={false}
-                  enabled={!this.getPath().usesControlIntervalGuessing}
-                  setEnabled={(_) => {}}
-                  roundingPrecision={0}
-                  number={this.getPath().defaultControlIntervalCount}
-                  setNumber={(count) => {
-                    this.getPath().setDefaultControlIntervalCounts(count);
-                  }}
-                  titleTooltip="When not guessing, how many samples to use?"
-                ></Input>
-              </InputList>
-            </span>
+            <span>No Settings</span>
+            <span></span>
           </>
-        )}
+        )} */}
       </span>
     );
   }

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -233,8 +233,6 @@ export const DocumentStore = types
               pathStore.trajectory.setWaypoints(result.trajectory.waypoints);
 
               pathStore.setSnapshot(result.snapshot);
-              // set this within the group so it gets picked up in the autosave
-              pathStore.setIsTrajectoryStale(false);
               self.history.stopGroup();
             });
           },
@@ -246,7 +244,6 @@ export const DocumentStore = types
         .finally(() => {
           // none of the below should trigger autosave
           pathStore.ui.setGenerating(false);
-          pathStore.setIsTrajectoryStale(false);
         });
     }
   }))

--- a/src/document/path/HolonomicPathStore.ts
+++ b/src/document/path/HolonomicPathStore.ts
@@ -23,11 +23,7 @@ export const HolonomicPathStore = types
     trajectory: ChoreoTrajectoryStore,
     ui: PathUIStore,
     name: "",
-    uuid: types.identifier,
-    isTrajectoryStale: true,
-    usesControlIntervalGuessing: true,
-    defaultControlIntervalCount: 40,
-    usesDefaultObstacles: true
+    uuid: types.identifier
   })
 
   .views((self) => {
@@ -69,21 +65,9 @@ export const HolonomicPathStore = types
       setSnapshot(snap: ChoreoPath<number>) {
         self.snapshot = snap;
       },
-      setIsTrajectoryStale(isTrajectoryStale: boolean) {
-        getEnv<Env>(self).withoutUndo(() => {
-          self.isTrajectoryStale = isTrajectoryStale;
-        });
-      },
-      setControlIntervalGuessing(value: boolean) {
-        self.usesControlIntervalGuessing = value;
-      },
-      setDefaultControlIntervalCounts(counts: number) {
-        self.defaultControlIntervalCount = counts;
-      },
       setName(name: string) {
         self.name = name;
       },
-
       addWaypoint(waypoint?: Partial<Waypoint<Expr>>): IHolonomicWaypointStore {
         self.params.waypoints.push(
           getEnv<Env>(self).create.WaypointStore(


### PR DESCRIPTION
Path Config panel is temporarily disabled, but other path-wide configs could go there.
Stale indicator will be replaced with comparison against snapshot
usesDefaultObstacles was never used in logic.