### PR TITLE
[trajoptlib] Make GetIndex() usage consistent and fix GetIndex()

### DIFF
--- a/trajoptlib/include/trajopt/util/GenerateLinearInitialGuess.hpp
+++ b/trajoptlib/include/trajopt/util/GenerateLinearInitialGuess.hpp
@@ -25,7 +25,7 @@ inline Solution GenerateLinearInitialGuess(
     const std::vector<std::vector<Pose2d>>& initialGuessPoints,
     const std::vector<size_t> controlIntervalCounts) {
   size_t wptCnt = controlIntervalCounts.size() + 1;
-  size_t sampTot = GetIndex(controlIntervalCounts, wptCnt, 0);
+  size_t sampTot = GetIndex(controlIntervalCounts, wptCnt - 1, 0) + 1;
 
   Solution initialGuess;
 

--- a/trajoptlib/include/trajopt/util/TrajoptUtil.hpp
+++ b/trajoptlib/include/trajopt/util/TrajoptUtil.hpp
@@ -14,18 +14,16 @@ namespace trajopt {
  * sample point ("dt" does not, "x" does).
  *
  * @param N The control interval counts of each segment, in order.
- * @param wptIndex The waypoint index (1 + segment index).
- * @param sampIndex The sample index within the segment.
+ * @param wptIndex The waypoint index, 0 indexed.
+ * @param sampIndex The sample index within the segment, 0 indexed.
  * @return The index in the array.
  */
 inline size_t GetIndex(const std::vector<size_t>& N, size_t wptIndex,
                        size_t sampIndex = 0) {
   size_t index = 0;
-  if (wptIndex > 0) {
-    ++index;
-  }
-  for (size_t _wptIndex = 1; _wptIndex < wptIndex; ++_wptIndex) {
-    index += N.at(_wptIndex - 1);
+
+  for (size_t _wptIndex = 0; _wptIndex < wptIndex; ++_wptIndex) {
+    index += N.at(_wptIndex);
   }
   index += sampIndex;
   return index;

--- a/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
+++ b/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
@@ -52,9 +52,10 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
       callback(soln, handle);
     }
   });
-  size_t wptCnt = 1 + Ns.size();
-  size_t sgmtCnt = Ns.size();
-  size_t sampTot = GetIndex(Ns, wptCnt, 0);
+
+  size_t wptCnt = path.waypoints.size();
+  size_t sgmtCnt = path.waypoints.size() - 1;
+  size_t sampTot = GetIndex(Ns, wptCnt - 1, 0) + 1;
 
   x.reserve(sampTot);
   y.reserve(sampTot);
@@ -165,11 +166,11 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
   problem.Minimize(std::move(T_tot));
 
   // Apply kinematics constraints
-  for (size_t wptIndex = 1; wptIndex < wptCnt; ++wptIndex) {
-    size_t N_sgmt = Ns.at(wptIndex - 1);
-    auto dt_sgmt = dts.at(wptIndex - 1);
+  for (size_t wptIndex = 0; wptIndex < wptCnt - 1; ++wptIndex) {
+    size_t N_sgmt = Ns.at(wptIndex);
+    auto dt_sgmt = dts.at(wptIndex);
 
-    for (size_t sampIndex = 0; sampIndex < N_sgmt; ++sampIndex) {
+    for (size_t sampIndex = 1; sampIndex <= N_sgmt; ++sampIndex) {
       size_t index = GetIndex(Ns, wptIndex, sampIndex);
 
       Translation2v x_n{x.at(index), y.at(index)};
@@ -189,16 +190,18 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
           (vR.at(index - 1) - vL.at(index - 1)) / path.drivetrain.trackwidth;
 
       Translation2v a_n = WheelToChassisSpeeds(aL.at(index), aR.at(index));
+      Translation2v a_n_1 =
+          WheelToChassisSpeeds(aL.at(index - 1), aR.at(index - 1));
 
-      problem.SubjectTo(x_n_1 + v_n * dt_sgmt + a_n * 0.5 * dt_sgmt * dt_sgmt ==
-                        x_n);
+      problem.SubjectTo(
+          x_n_1 + v_n_1 * dt_sgmt + a_n_1 * 0.5 * dt_sgmt * dt_sgmt == x_n);
 
       auto lhs = heading.at(index) - heading.at(index - 1);
       auto rhs = omega_n * dt_sgmt;
       problem.SubjectTo(slp::cos(lhs) == slp::cos(rhs));
       problem.SubjectTo(slp::sin(lhs) == slp::sin(rhs));
 
-      problem.SubjectTo(v_n_1 + a_n * dt_sgmt == v_n);
+      problem.SubjectTo(v_n_1 + a_n_1 * dt_sgmt == v_n);
     }
   }
 
@@ -248,7 +251,7 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
   for (size_t wptIndex = 0; wptIndex < wptCnt; ++wptIndex) {
     for (auto& constraint : path.waypoints.at(wptIndex).waypointConstraints) {
       // First index of next wpt - 1
-      size_t index = GetIndex(Ns, wptIndex + 1, 0) - 1;
+      size_t index = GetIndex(Ns, wptIndex, 0);
 
       Pose2v pose{x.at(index), y.at(index), {heading.at(index)}};
 
@@ -276,8 +279,8 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
   for (size_t sgmtIndex = 0; sgmtIndex < sgmtCnt; ++sgmtIndex) {
     for (auto& constraint :
          path.waypoints.at(sgmtIndex + 1).segmentConstraints) {
-      size_t startIndex = GetIndex(Ns, sgmtIndex + 1, 0);
-      size_t endIndex = GetIndex(Ns, sgmtIndex + 2, 0);
+      size_t startIndex = GetIndex(Ns, sgmtIndex, 0);
+      size_t endIndex = GetIndex(Ns, sgmtIndex + 1, 0);
 
       for (size_t index = startIndex; index < endIndex; ++index) {
         Pose2v pose{x.at(index), y.at(index), {heading.at(index)}};

--- a/trajoptlib/test/src/util/TrajoptUtilTest.cpp
+++ b/trajoptlib/test/src/util/TrajoptUtilTest.cpp
@@ -8,12 +8,12 @@
 TEST_CASE("TrajoptUtil - GetIndex()", "[TrajoptUtil]") {
   auto result0 = trajopt::GetIndex({2, 3}, 0, 0);
   auto result1 = trajopt::GetIndex({2, 3}, 1, 1);
-  auto result2 = trajopt::GetIndex({2, 3}, 2, 2);
-  auto result3 = trajopt::GetIndex({2, 3}, 3, 0);
+  auto result2 = trajopt::GetIndex({2, 3}, 1, 2);
+  auto result3 = trajopt::GetIndex({2, 3}, 2, 0);
   CHECK(result0 == 0);
-  CHECK(result1 == 2);
-  CHECK(result2 == 5);
-  CHECK(result3 == 6);
+  CHECK(result1 == 3);
+  CHECK(result2 == 4);
+  CHECK(result3 == 5);
 }
 
 TEST_CASE("TrajoptUtil - Linspace()", "[TrajoptUtil]") {


### PR DESCRIPTION
GetIndex() previously had an increment on all calls to it. It also had inconsistent usage where uses assumed both 0 and 1 based indexing. This PR changes the function to be 0 indexed on waypoints and samples within segments.

the relevant code in swerve and differential drive generators have been updated. 

![image](https://github.com/user-attachments/assets/0c7a5c11-b1ee-4b93-8415-01390edd81d4)
