### PR TITLE
Use std instead of core

### DIFF
--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -106,7 +106,7 @@ where
         _ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
         mut writer: tracing_subscriber::fmt::format::Writer<'_>,
         event: &tracing::Event<'_>,
-    ) -> core::fmt::Result {
+    ) -> std::fmt::Result {
         let meta = event.metadata();
 
         let mut visitor = MetaVisitor::default();
@@ -220,7 +220,7 @@ where
         _ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
         mut writer: tracing_subscriber::fmt::format::Writer<'_>,
         event: &tracing::Event<'_>,
-    ) -> core::fmt::Result {
+    ) -> std::fmt::Result {
         let meta = event.metadata();
 
         let mut visitor = MetaVisitor::default();

--- a/trajoptlib/examples/differential.rs
+++ b/trajoptlib/examples/differential.rs
@@ -1,4 +1,4 @@
-use core::f64;
+use std::f64;
 
 use trajoptlib::{DifferentialDrivetrain, DifferentialPathBuilder, PathBuilder};
 


### PR DESCRIPTION
We aren't no-std so we should be using the std namespace