### PR TITLE
Sort C++ PathBuilder functions and remove PathBuilder Rust trait

### DIFF
--- a/src-core/src/generation/transformers/callback.rs
+++ b/src-core/src/generation/transformers/callback.rs
@@ -7,13 +7,6 @@ use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, Generat
 
 pub struct CallbackSetter;
 
-impl CallbackSetter {
-    // separately implement initialize to share between differential and swerve
-    fn initialize(_: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        FeatureLockedTransformer::always(Self)
-    }
-}
-
 fn swerve_status_callback(trajectory: SwerveTrajectory, handle: i64) {
     let tx_opt = PROGRESS_SENDER_LOCK.get();
     if let Some(tx) = tx_opt {
@@ -31,19 +24,21 @@ fn differential_status_callback(trajectory: DifferentialTrajectory, handle: i64)
 }
 
 impl SwerveGenerationTransformer for CallbackSetter {
-    fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
+    fn initialize(_: &GenerationContext) -> FeatureLockedTransformer<Self> {
+        FeatureLockedTransformer::always(Self)
     }
-    fn transform(&self, builder: &mut trajoptlib::SwervePathBuilder) {
-        builder.add_progress_callback(swerve_status_callback);
+
+    fn transform(&self, generator: &mut trajoptlib::SwerveTrajectoryGenerator) {
+        generator.add_callback(swerve_status_callback);
     }
 }
 
 impl DifferentialGenerationTransformer for CallbackSetter {
-    fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
+    fn initialize(_: &GenerationContext) -> FeatureLockedTransformer<Self> {
+        FeatureLockedTransformer::always(Self)
     }
-    fn transform(&self, builder: &mut trajoptlib::DifferentialPathBuilder) {
-        builder.add_progress_callback(differential_status_callback);
+
+    fn transform(&self, generator: &mut trajoptlib::DifferentialTrajectoryGenerator) {
+        generator.add_callback(differential_status_callback);
     }
 }

--- a/src-core/src/generation/transformers/drivetrain_and_bumpers.rs
+++ b/src-core/src/generation/transformers/drivetrain_and_bumpers.rs
@@ -1,6 +1,6 @@
-use trajoptlib::{DifferentialDrivetrain, PathBuilder, SwerveDrivetrain};
+use trajoptlib::{DifferentialDrivetrain, SwerveDrivetrain};
 
-use crate::spec::project::{RobotConfig};
+use crate::spec::project::RobotConfig;
 
 use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext, SwerveGenerationTransformer};
 
@@ -9,20 +9,14 @@ pub struct DrivetrainAndBumpersSetter {
     config: RobotConfig<f64>
 }
 
-impl DrivetrainAndBumpersSetter {
-    // separately implement initialize to share between differential and swerve
-    fn initialize(ctx: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        FeatureLockedTransformer::always(Self {
-            config: ctx.project.config.snapshot()
-        })
-    }
-}
-
 impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
+        FeatureLockedTransformer::always(Self {
+            config: context.project.config.snapshot()
+        })
     }
-    fn transform(&self, builder: &mut trajoptlib::SwervePathBuilder) {
+
+    fn transform(&self, generator: &mut trajoptlib::SwerveTrajectoryGenerator) {
         let config = &self.config;
         let drivetrain = SwerveDrivetrain {
             mass: config.mass,
@@ -35,8 +29,8 @@ impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
                 .module_translations(),
         };
 
-        builder.set_drivetrain(&drivetrain);
-        builder.set_bumpers(
+        generator.set_drivetrain(&drivetrain);
+        generator.set_bumpers(
             config.bumper.front,
             config.bumper.side,
             config.bumper.side,
@@ -47,9 +41,12 @@ impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
 
 impl DifferentialGenerationTransformer for DrivetrainAndBumpersSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
+        FeatureLockedTransformer::always(Self {
+            config: context.project.config.snapshot()
+        })
     }
-    fn transform(&self, builder: &mut trajoptlib::DifferentialPathBuilder) {
+
+    fn transform(&self, generator: &mut trajoptlib::DifferentialTrajectoryGenerator) {
         let config = &self.config;
         let drivetrain = DifferentialDrivetrain {
             mass: config.mass,
@@ -61,8 +58,8 @@ impl DifferentialGenerationTransformer for DrivetrainAndBumpersSetter {
             trackwidth: config.differential_track_width,
         };
 
-        builder.set_drivetrain(&drivetrain);
-        builder.set_bumpers(
+        generator.set_drivetrain(&drivetrain);
+        generator.set_bumpers(
             config.bumper.front,
             config.bumper.side,
             config.bumper.side,

--- a/src-core/src/generation/transformers/interval_count.rs
+++ b/src-core/src/generation/transformers/interval_count.rs
@@ -1,4 +1,4 @@
-use trajoptlib::{PathBuilder, Pose2d};
+use trajoptlib::Pose2d;
 
 use crate::{generation::intervals::guess_control_interval_counts, spec::trajectory::Waypoint};
 
@@ -10,15 +10,15 @@ pub struct IntervalCountSetter {
     waypoints: Vec<Waypoint<f64>>
 }
 
-impl IntervalCountSetter {
-    // separately implement initialize to share between differential and swerve
-    fn initialize(ctx: &GenerationContext) -> FeatureLockedTransformer<Self> {
+impl SwerveGenerationTransformer for IntervalCountSetter {
+    fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            counts: guess_control_interval_counts(&ctx.project.config.snapshot(), &ctx.params).unwrap_or_default(),
-            waypoints: ctx.params.waypoints.clone()
+            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
+            waypoints: context.params.waypoints.clone()
         })
     }
-    fn transform<T: PathBuilder>(&self, builder: &mut T) {
+
+    fn transform(&self, generator: &mut trajoptlib::SwerveTrajectoryGenerator) {
         let waypoints = &self.waypoints;
         let mut guess_points_after_waypoint = Vec::new();
         let mut control_interval_counts = Vec::new();
@@ -38,15 +38,15 @@ impl IntervalCountSetter {
                 }
             } else {
                 if wpt_cnt > 0 {
-                    builder.sgmt_initial_guess_points(wpt_cnt - 1, &guess_points_after_waypoint);
+                    generator.sgmt_initial_guess_points(wpt_cnt - 1, &guess_points_after_waypoint);
                 }
                 guess_points_after_waypoint.clear();
                 if wpt.fix_heading && wpt.fix_translation {
-                    builder.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
                 } else if wpt.fix_translation {
-                    builder.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
                 } else {
-                    builder.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
                 }
                 wpt_cnt += 1;
                 if i != waypoints.len() - 1 {
@@ -55,26 +55,55 @@ impl IntervalCountSetter {
             }
         }
 
-        println!("Control Interval Counts: {:?}", control_interval_counts);
-
-        builder.set_control_interval_counts(control_interval_counts);
-    }
-}
-
-impl SwerveGenerationTransformer for IntervalCountSetter {
-    fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
-    }
-    fn transform(&self, builder: &mut trajoptlib::SwervePathBuilder) {
-        self.transform(builder);
+        generator.set_control_interval_counts(control_interval_counts);
     }
 }
 
 impl DifferentialGenerationTransformer for IntervalCountSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
-        Self::initialize(context)
+        FeatureLockedTransformer::always(Self {
+            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
+            waypoints: context.params.waypoints.clone()
+        })
     }
-    fn transform(&self, builder: &mut trajoptlib::DifferentialPathBuilder) {
-        self.transform(builder);
+
+    fn transform(&self, generator: &mut trajoptlib::DifferentialTrajectoryGenerator) {
+        let waypoints = &self.waypoints;
+        let mut guess_points_after_waypoint = Vec::new();
+        let mut control_interval_counts = Vec::new();
+        let mut wpt_cnt = 0;
+        for i in 0..waypoints.len() {
+            let wpt = &waypoints[i];
+            // add initial guess points (actually unconstrained empty wpts in Choreo terms)
+            if wpt.is_initial_guess && !wpt.fix_heading && !wpt.fix_translation {
+                let guess_point = Pose2d {
+                    x: wpt.x,
+                    y: wpt.y,
+                    heading: wpt.heading,
+                };
+                guess_points_after_waypoint.push(guess_point);
+                if let Some(last) = control_interval_counts.last_mut() {
+                    *last += self.counts[i];
+                }
+            } else {
+                if wpt_cnt > 0 {
+                    generator.sgmt_initial_guess_points(wpt_cnt - 1, &guess_points_after_waypoint);
+                }
+                guess_points_after_waypoint.clear();
+                if wpt.fix_heading && wpt.fix_translation {
+                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                } else if wpt.fix_translation {
+                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                } else {
+                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                }
+                wpt_cnt += 1;
+                if i != waypoints.len() - 1 {
+                    control_interval_counts.push(self.counts[i]);
+                }
+            }
+        }
+
+        generator.set_control_interval_counts(control_interval_counts);
     }
 }

--- a/trajoptlib/examples/Differential/src/Main.cpp
+++ b/trajoptlib/examples/Differential/src/Main.cpp
@@ -33,7 +33,7 @@ int main() {
     path.PoseWpt(1, 1.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -48,7 +48,7 @@ int main() {
     path.PoseWpt(1, 2.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -64,7 +64,7 @@ int main() {
     path.PoseWpt(2, 2.0, 0.0, std::numbers::pi / 2);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({50, 50});
+    path.SetControlIntervalCounts({50, 50});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -78,7 +78,7 @@ int main() {
     path.PoseWpt(0, 0.0, 0.0, 0.0);
     path.PoseWpt(1, 0.0, 1.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -109,7 +109,7 @@ int main() {
     path.PoseWpt(1, 1.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -145,7 +145,7 @@ int main() {
 
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(4, zeroLinearVelocity);
-    path.ControlIntervalCounts({40, 30, 30, 40});
+    path.SetControlIntervalCounts({40, 30, 30, 40});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -176,7 +176,7 @@ int main() {
 
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({50});
+    path.SetControlIntervalCounts({50});
 
     trajopt::DifferentialTrajectoryGenerator generator{path};
     [[maybe_unused]]

--- a/trajoptlib/examples/Swerve/src/Main.cpp
+++ b/trajoptlib/examples/Swerve/src/Main.cpp
@@ -33,7 +33,7 @@ int main() {
     path.PoseWpt(1, 1.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -48,7 +48,7 @@ int main() {
     path.PoseWpt(1, 2.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -64,7 +64,7 @@ int main() {
     path.PoseWpt(2, 2.0, 0.0, std::numbers::pi / 2);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40, 40});
+    path.SetControlIntervalCounts({40, 40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -78,7 +78,7 @@ int main() {
     path.PoseWpt(0, 0.0, 0.0, 0.0);
     path.PoseWpt(1, 0.0, 1.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -110,7 +110,7 @@ int main() {
     path.PoseWpt(1, 1.0, 0.0, 0.0);
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({40});
+    path.SetControlIntervalCounts({40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -146,7 +146,7 @@ int main() {
 
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(4, zeroLinearVelocity);
-    path.ControlIntervalCounts({40, 30, 30, 40});
+    path.SetControlIntervalCounts({40, 30, 30, 40});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]
@@ -177,7 +177,7 @@ int main() {
 
     path.WptConstraint(0, zeroLinearVelocity);
     path.WptConstraint(1, zeroLinearVelocity);
-    path.ControlIntervalCounts({30});
+    path.SetControlIntervalCounts({30});
 
     trajopt::SwerveTrajectoryGenerator generator{path};
     [[maybe_unused]]

--- a/trajoptlib/examples/differential.rs
+++ b/trajoptlib/examples/differential.rs
@@ -1,6 +1,6 @@
 use std::f64;
 
-use trajoptlib::{DifferentialDrivetrain, DifferentialPathBuilder, PathBuilder};
+use trajoptlib::{DifferentialDrivetrain, DifferentialTrajectoryGenerator};
 
 fn main() {
     let drivetrain = DifferentialDrivetrain {
@@ -12,22 +12,20 @@ fn main() {
         trackwidth: 0.5588,                                                        // m
     };
 
-    let mut path = DifferentialPathBuilder::new();
+    let mut generator = DifferentialTrajectoryGenerator::new();
 
-    path.add_progress_callback(|trajectory, handle| {
-        println!("{:?}: handle {}", trajectory, handle)
-    });
-    path.set_drivetrain(&drivetrain);
-    path.set_bumpers(0.65, 0.65, 0.65, 0.65);
+    generator.add_callback(|trajectory, handle| println!("{:?}: handle {}", trajectory, handle));
+    generator.set_drivetrain(&drivetrain);
+    generator.set_bumpers(0.65, 0.65, 0.65, 0.65);
 
-    path.pose_wpt(0, 0.0, 0.0, 0.0);
-    path.pose_wpt(1, 1.0, 0.0, 0.0);
+    generator.pose_wpt(0, 0.0, 0.0, 0.0);
+    generator.pose_wpt(1, 1.0, 0.0, 0.0);
 
-    path.wpt_angular_velocity_max_magnitude(0, 0.0);
-    path.wpt_angular_velocity_max_magnitude(1, 0.0);
-    // path.sgmt_keep_out_circle(0, 1, 0.5, 0.1, 0.2);
+    generator.wpt_angular_velocity_max_magnitude(0, 0.0);
+    generator.wpt_angular_velocity_max_magnitude(1, 0.0);
+    // generator.sgmt_keep_out_circle(0, 1, 0.5, 0.1, 0.2);
 
-    path.set_control_interval_counts(vec![40]);
+    generator.set_control_interval_counts(vec![40]);
 
-    println!("{:?}", path.generate(true, 0));
+    println!("{:?}", generator.generate(true, 0));
 }

--- a/trajoptlib/examples/swerve.rs
+++ b/trajoptlib/examples/swerve.rs
@@ -1,4 +1,4 @@
-use trajoptlib::{PathBuilder, SwerveDrivetrain, SwervePathBuilder, Translation2d};
+use trajoptlib::{SwerveDrivetrain, SwerveTrajectoryGenerator, Translation2d};
 
 fn main() {
     let drivetrain = SwerveDrivetrain {
@@ -15,22 +15,20 @@ fn main() {
         ],
     };
 
-    let mut path = SwervePathBuilder::new();
+    let mut generator = SwerveTrajectoryGenerator::new();
 
-    path.add_progress_callback(|trajectory, handle| {
-        println!("{:?}: handle {}", trajectory, handle)
-    });
-    path.set_drivetrain(&drivetrain);
-    path.set_bumpers(0.65, 0.65, 0.65, 0.65);
+    generator.add_callback(|trajectory, handle| println!("{:?}: handle {}", trajectory, handle));
+    generator.set_drivetrain(&drivetrain);
+    generator.set_bumpers(0.65, 0.65, 0.65, 0.65);
 
-    path.pose_wpt(0, 0.0, 0.0, 0.0);
-    path.pose_wpt(1, 1.0, 0.0, 0.0);
+    generator.pose_wpt(0, 0.0, 0.0, 0.0);
+    generator.pose_wpt(1, 1.0, 0.0, 0.0);
 
-    path.wpt_angular_velocity_max_magnitude(0, 0.0);
-    path.wpt_angular_velocity_max_magnitude(1, 0.0);
-    path.sgmt_keep_out_circle(0, 1, 0.5, 0.1, 0.2);
+    generator.wpt_angular_velocity_max_magnitude(0, 0.0);
+    generator.wpt_angular_velocity_max_magnitude(1, 0.0);
+    generator.sgmt_keep_out_circle(0, 1, 0.5, 0.1, 0.2);
 
-    path.set_control_interval_counts(vec![40]);
+    generator.set_control_interval_counts(vec![40]);
 
-    println!("{:?}", path.generate(true, 0));
+    println!("{:?}", generator.generate(true, 0));
 }

--- a/trajoptlib/src/RustFFI.hpp
+++ b/trajoptlib/src/RustFFI.hpp
@@ -36,21 +36,20 @@ struct Pose2d;
 struct SwerveDrivetrain;
 struct DifferentialDrivetrain;
 
-class SwervePathBuilder {
+class SwerveTrajectoryGenerator {
  public:
-  SwervePathBuilder() = default;
+  SwerveTrajectoryGenerator() = default;
 
   void set_drivetrain(const SwerveDrivetrain& drivetrain);
   void set_bumpers(double front, double left, double right, double back);
   void set_control_interval_counts(const rust::Vec<size_t> counts);
+  void sgmt_initial_guess_points(size_t from_index,
+                                 const rust::Vec<Pose2d>& guess_points);
 
   void pose_wpt(size_t index, double x, double y, double heading);
   void translation_wpt(size_t index, double x, double y, double heading_guess);
   void empty_wpt(size_t index, double x_guess, double y_guess,
                  double heading_guess);
-
-  void sgmt_initial_guess_points(size_t from_index,
-                                 const rust::Vec<Pose2d>& guess_points);
 
   void wpt_linear_velocity_direction(size_t index, double angle);
   void wpt_linear_velocity_max_magnitude(size_t index, double magnitude);
@@ -66,7 +65,6 @@ class SwervePathBuilder {
   void wpt_keep_in_lane(size_t index, double center_line_start_x,
                         double center_line_start_y, double center_line_end_x,
                         double center_line_end_y, double tolerance);
-
   void wpt_keep_out_circle(size_t index, double field_point_x,
                            double field_point_y, double keep_in_radius);
 
@@ -91,9 +89,19 @@ class SwervePathBuilder {
                          double center_line_start_x, double center_line_start_y,
                          double center_line_end_x, double center_line_end_y,
                          double tolerance);
-
   void sgmt_keep_out_circle(size_t from_index, size_t to_index, double x,
                             double y, double radius);
+
+  /**
+   * Add a callback that will be called on each iteration of the solver.
+   *
+   * @param callback A `fn` (not a closure) to be executed. The callback's first
+   *   parameter will be a `trajopt::SwerveTrajectory`, and the second parameter
+   *   will be an `i64` equal to the handle passed in `generate()`.
+   *
+   * This function can be called multiple times to add multiple callbacks.
+   */
+  void add_callback(rust::Fn<void(SwerveTrajectory, int64_t)> callback);
 
   // TODO: Return std::expected<SwerveTrajectory, sleipnir::SolverExitCondition>
   // instead of throwing exception, once cxx supports it
@@ -101,28 +109,24 @@ class SwervePathBuilder {
   // https://github.com/dtolnay/cxx/issues/1052
   SwerveTrajectory generate(bool diagnostics = false, int64_t handle = 0) const;
 
-  void add_progress_callback(
-      rust::Fn<void(SwerveTrajectory, int64_t)> callback);
-
  private:
   trajopt::SwervePathBuilder path_builder;
 };
 
-class DifferentialPathBuilder {
+class DifferentialTrajectoryGenerator {
  public:
-  DifferentialPathBuilder() = default;
+  DifferentialTrajectoryGenerator() = default;
 
   void set_drivetrain(const DifferentialDrivetrain& drivetrain);
   void set_bumpers(double front, double left, double right, double back);
   void set_control_interval_counts(const rust::Vec<size_t> counts);
+  void sgmt_initial_guess_points(size_t from_index,
+                                 const rust::Vec<Pose2d>& guess_points);
 
   void pose_wpt(size_t index, double x, double y, double heading);
   void translation_wpt(size_t index, double x, double y, double heading_guess);
   void empty_wpt(size_t index, double x_guess, double y_guess,
                  double heading_guess);
-
-  void sgmt_initial_guess_points(size_t from_index,
-                                 const rust::Vec<Pose2d>& guess_points);
 
   void wpt_linear_velocity_direction(size_t index, double angle);
   void wpt_linear_velocity_max_magnitude(size_t index, double magnitude);
@@ -165,6 +169,17 @@ class DifferentialPathBuilder {
   void sgmt_keep_out_circle(size_t from_index, size_t to_index, double x,
                             double y, double radius);
 
+  /**
+   * Add a callback that will be called on each iteration of the solver.
+   *
+   * @param callback A `fn` (not a closure) to be executed. The callback's first
+   *   parameter will be a `trajopt::DifferentialTrajectory`, and the second
+   *   parameter will be an `i64` equal to the handle passed in `generate()`.
+   *
+   * This function can be called multiple times to add multiple callbacks.
+   */
+  void add_callback(rust::Fn<void(DifferentialTrajectory, int64_t)> callback);
+
   // TODO: Return std::expected<DifferentialTrajectory,
   // sleipnir::SolverExitCondition> instead of throwing exception, once cxx
   // supports it
@@ -173,16 +188,14 @@ class DifferentialPathBuilder {
   DifferentialTrajectory generate(bool diagnostics = false,
                                   int64_t handle = 0) const;
 
-  void add_progress_callback(
-      rust::Fn<void(DifferentialTrajectory, int64_t)> callback);
-
  private:
   trajopt::DifferentialPathBuilder path_builder;
 };
 
-std::unique_ptr<SwervePathBuilder> swerve_path_builder_new();
+std::unique_ptr<SwerveTrajectoryGenerator> swerve_trajectory_generator_new();
 
-std::unique_ptr<DifferentialPathBuilder> differential_path_builder_new();
+std::unique_ptr<DifferentialTrajectoryGenerator>
+differential_trajectory_generator_new();
 
 void cancel_all();
 

--- a/trajoptlib/src/lib.rs
+++ b/trajoptlib/src/lib.rs
@@ -76,265 +76,111 @@ mod ffi {
     unsafe extern "C++" {
         include!("RustFFI.hpp");
 
-        type SwervePathBuilder;
+        type SwerveTrajectoryGenerator;
 
-        fn set_drivetrain(self: Pin<&mut SwervePathBuilder>, drivetrain: &SwerveDrivetrain);
+        fn swerve_trajectory_generator_new() -> UniquePtr<SwerveTrajectoryGenerator>;
+
+        fn set_drivetrain(self: Pin<&mut SwerveTrajectoryGenerator>, drivetrain: &SwerveDrivetrain);
+
         fn set_bumpers(
-            self: Pin<&mut SwervePathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             front: f64,
             left: f64,
             right: f64,
             back: f64,
         );
-        fn set_control_interval_counts(self: Pin<&mut SwervePathBuilder>, counts: Vec<usize>);
 
-        fn pose_wpt(self: Pin<&mut SwervePathBuilder>, index: usize, x: f64, y: f64, heading: f64);
-        fn translation_wpt(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            x: f64,
-            y: f64,
-            heading_guess: f64,
-        );
-        fn empty_wpt(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            x_guess: f64,
-            y_guess: f64,
-            heading_guess: f64,
+        fn set_control_interval_counts(
+            self: Pin<&mut SwerveTrajectoryGenerator>,
+            counts: Vec<usize>,
         );
 
-        fn sgmt_initial_guess_points(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            guess_points: &Vec<Pose2d>,
-        );
-
-        fn wpt_linear_velocity_direction(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            angle: f64,
-        );
-        fn wpt_linear_velocity_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            magnitude: f64,
-        );
-        fn wpt_angular_velocity_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            angular_velocity: f64,
-        );
-        fn wpt_linear_acceleration_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            magnitude: f64,
-        );
-        fn wpt_point_at(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            field_point_x: f64,
-            field_point_y: f64,
-            heading_tolerance: f64,
-            flip: bool,
-        );
-        fn wpt_keep_in_circle(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            field_point_x: f64,
-            field_point_y: f64,
-            keep_in_radius: f64,
-        );
-        fn wpt_keep_in_polygon(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            field_points_x: Vec<f64>,
-            field_points_y: Vec<f64>,
-        );
-        fn wpt_keep_in_lane(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            center_line_start_x: f64,
-            center_line_start_y: f64,
-            center_line_end_x: f64,
-            center_line_end_y: f64,
-            tolerance: f64,
-        );
-        fn wpt_keep_out_circle(
-            self: Pin<&mut SwervePathBuilder>,
-            index: usize,
-            field_point_x: f64,
-            field_point_y: f64,
-            keep_in_radius: f64,
-        );
-
-        fn sgmt_linear_velocity_direction(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            angle: f64,
-        );
-        fn sgmt_linear_velocity_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            magnitude: f64,
-        );
-        fn sgmt_angular_velocity_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            angular_velocity: f64,
-        );
-        fn sgmt_linear_acceleration_max_magnitude(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            magnitude: f64,
-        );
-        fn sgmt_point_at(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            field_point_x: f64,
-            field_point_y: f64,
-            heading_tolerance: f64,
-            flip: bool,
-        );
-        fn sgmt_keep_in_circle(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            field_point_x: f64,
-            field_point_y: f64,
-            keep_in_radius: f64,
-        );
-        pub fn sgmt_keep_in_polygon(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            field_points_x: Vec<f64>,
-            field_points_y: Vec<f64>,
-        );
-        #[allow(clippy::too_many_arguments)]
-        fn sgmt_keep_in_lane(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            center_line_start_x: f64,
-            center_line_start_y: f64,
-            center_line_end_x: f64,
-            center_line_end_y: f64,
-            tolerance: f64,
-        );
-        fn sgmt_keep_out_circle(
-            self: Pin<&mut SwervePathBuilder>,
-            from_index: usize,
-            to_index: usize,
-            x: f64,
-            y: f64,
-            radius: f64,
-        );
-
-        fn generate(
-            self: &SwervePathBuilder,
-            diagnostics: bool,
-            uuid: i64,
-        ) -> Result<SwerveTrajectory>;
-
-        fn add_progress_callback(
-            self: Pin<&mut SwervePathBuilder>,
-            callback: fn(SwerveTrajectory, i64),
-        );
-
-        fn swerve_path_builder_new() -> UniquePtr<SwervePathBuilder>;
-
-        type DifferentialPathBuilder;
-
-        fn set_drivetrain(
-            self: Pin<&mut DifferentialPathBuilder>,
-            drivetrain: &DifferentialDrivetrain,
-        );
-        fn set_bumpers(
-            self: Pin<&mut DifferentialPathBuilder>,
-            front: f64,
-            left: f64,
-            right: f64,
-            back: f64,
-        );
-        fn set_control_interval_counts(self: Pin<&mut DifferentialPathBuilder>, counts: Vec<usize>);
+        // Pose constraints
 
         fn pose_wpt(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             x: f64,
             y: f64,
             heading: f64,
         );
+
         fn translation_wpt(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             x: f64,
             y: f64,
             heading_guess: f64,
         );
+
         fn empty_wpt(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             x_guess: f64,
             y_guess: f64,
             heading_guess: f64,
         );
 
+        // Segment initial guess points setter
+
         fn sgmt_initial_guess_points(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             guess_points: &Vec<Pose2d>,
         );
 
+        // Constraints with waypoint scope
+
         fn wpt_linear_velocity_direction(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             angle: f64,
         );
+
         fn wpt_linear_velocity_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             magnitude: f64,
         );
+
         fn wpt_angular_velocity_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             angular_velocity: f64,
         );
+
         fn wpt_linear_acceleration_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             magnitude: f64,
         );
+
         fn wpt_point_at(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             field_point_x: f64,
             field_point_y: f64,
             heading_tolerance: f64,
             flip: bool,
         );
+
         fn wpt_keep_in_circle(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             field_point_x: f64,
             field_point_y: f64,
             keep_in_radius: f64,
         );
+
         fn wpt_keep_in_polygon(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             field_points_x: Vec<f64>,
             field_points_y: Vec<f64>,
         );
+
         fn wpt_keep_in_lane(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             center_line_start_x: f64,
             center_line_start_y: f64,
@@ -342,56 +188,75 @@ mod ffi {
             center_line_end_y: f64,
             tolerance: f64,
         );
+
         fn wpt_keep_out_circle(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             index: usize,
             field_point_x: f64,
             field_point_y: f64,
             keep_in_radius: f64,
         );
 
+        // Constraints with segment scope
+
         fn sgmt_linear_velocity_direction(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             angle: f64,
         );
+
         fn sgmt_linear_velocity_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             magnitude: f64,
         );
+
         fn sgmt_angular_velocity_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             angular_velocity: f64,
         );
+
         fn sgmt_linear_acceleration_max_magnitude(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             magnitude: f64,
         );
+
+        fn sgmt_point_at(
+            self: Pin<&mut SwerveTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            field_point_x: f64,
+            field_point_y: f64,
+            heading_tolerance: f64,
+            flip: bool,
+        );
+
         fn sgmt_keep_in_circle(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             field_point_x: f64,
             field_point_y: f64,
             keep_in_radius: f64,
         );
-        pub fn sgmt_keep_in_polygon(
-            self: Pin<&mut DifferentialPathBuilder>,
+
+        fn sgmt_keep_in_polygon(
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             field_points_x: Vec<f64>,
             field_points_y: Vec<f64>,
         );
+
         #[allow(clippy::too_many_arguments)]
         fn sgmt_keep_in_lane(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             center_line_start_x: f64,
@@ -402,7 +267,7 @@ mod ffi {
         );
 
         fn sgmt_keep_out_circle(
-            self: Pin<&mut DifferentialPathBuilder>,
+            self: Pin<&mut SwerveTrajectoryGenerator>,
             from_index: usize,
             to_index: usize,
             x: f64,
@@ -410,60 +275,397 @@ mod ffi {
             radius: f64,
         );
 
+        // Trajectory generator functions
+
+        fn add_callback(
+            self: Pin<&mut SwerveTrajectoryGenerator>,
+            callback: fn(SwerveTrajectory, i64),
+        );
+
         fn generate(
-            self: &DifferentialPathBuilder,
+            self: &SwerveTrajectoryGenerator,
+            diagnostics: bool,
+            uuid: i64,
+        ) -> Result<SwerveTrajectory>;
+
+        type DifferentialTrajectoryGenerator;
+
+        fn differential_trajectory_generator_new() -> UniquePtr<DifferentialTrajectoryGenerator>;
+
+        fn set_drivetrain(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            drivetrain: &DifferentialDrivetrain,
+        );
+
+        fn set_bumpers(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            front: f64,
+            left: f64,
+            right: f64,
+            back: f64,
+        );
+
+        fn set_control_interval_counts(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            counts: Vec<usize>,
+        );
+
+        // Pose constraints
+
+        fn pose_wpt(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            x: f64,
+            y: f64,
+            heading: f64,
+        );
+
+        fn translation_wpt(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            x: f64,
+            y: f64,
+            heading_guess: f64,
+        );
+
+        fn empty_wpt(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            x_guess: f64,
+            y_guess: f64,
+            heading_guess: f64,
+        );
+
+        // Segment initial guess points setter
+
+        fn sgmt_initial_guess_points(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            guess_points: &Vec<Pose2d>,
+        );
+
+        // Constraints with waypoint scope
+
+        fn wpt_linear_velocity_direction(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            angle: f64,
+        );
+
+        fn wpt_linear_velocity_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            magnitude: f64,
+        );
+
+        fn wpt_angular_velocity_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            angular_velocity: f64,
+        );
+
+        fn wpt_linear_acceleration_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            magnitude: f64,
+        );
+
+        fn wpt_point_at(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            field_point_x: f64,
+            field_point_y: f64,
+            heading_tolerance: f64,
+            flip: bool,
+        );
+
+        fn wpt_keep_in_circle(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            field_point_x: f64,
+            field_point_y: f64,
+            keep_in_radius: f64,
+        );
+
+        fn wpt_keep_in_polygon(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            field_points_x: Vec<f64>,
+            field_points_y: Vec<f64>,
+        );
+
+        fn wpt_keep_in_lane(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            center_line_start_x: f64,
+            center_line_start_y: f64,
+            center_line_end_x: f64,
+            center_line_end_y: f64,
+            tolerance: f64,
+        );
+
+        fn wpt_keep_out_circle(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            index: usize,
+            field_point_x: f64,
+            field_point_y: f64,
+            keep_in_radius: f64,
+        );
+
+        // Constraints with waypoint scope
+
+        fn sgmt_linear_velocity_direction(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            angle: f64,
+        );
+
+        fn sgmt_linear_velocity_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            magnitude: f64,
+        );
+
+        fn sgmt_angular_velocity_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            angular_velocity: f64,
+        );
+
+        fn sgmt_linear_acceleration_max_magnitude(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            magnitude: f64,
+        );
+
+        fn sgmt_keep_in_circle(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            field_point_x: f64,
+            field_point_y: f64,
+            keep_in_radius: f64,
+        );
+
+        fn sgmt_keep_in_polygon(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            field_points_x: Vec<f64>,
+            field_points_y: Vec<f64>,
+        );
+
+        #[allow(clippy::too_many_arguments)]
+        fn sgmt_keep_in_lane(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            center_line_start_x: f64,
+            center_line_start_y: f64,
+            center_line_end_x: f64,
+            center_line_end_y: f64,
+            tolerance: f64,
+        );
+
+        fn sgmt_keep_out_circle(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            from_index: usize,
+            to_index: usize,
+            x: f64,
+            y: f64,
+            radius: f64,
+        );
+
+        // Trajectory generator
+
+        fn add_callback(
+            self: Pin<&mut DifferentialTrajectoryGenerator>,
+            callback: fn(DifferentialTrajectory, i64),
+        );
+
+        fn generate(
+            self: &DifferentialTrajectoryGenerator,
             diagnostics: bool,
             uuid: i64,
         ) -> Result<DifferentialTrajectory>;
 
-        fn add_progress_callback(
-            self: Pin<&mut DifferentialPathBuilder>,
-            callback: fn(DifferentialTrajectory, i64),
-        );
-
-        fn differential_path_builder_new() -> UniquePtr<DifferentialPathBuilder>;
+        // Cancel all generators
 
         fn cancel_all();
     }
 }
 
-pub trait PathBuilder: Any {
-    fn set_bumpers(&mut self, front: f64, left: f64, right: f64, back: f64);
-    fn set_control_interval_counts(&mut self, counts: Vec<usize>);
+pub struct SwerveTrajectoryGenerator {
+    generator: cxx::UniquePtr<crate::ffi::SwerveTrajectoryGenerator>,
+}
 
-    fn pose_wpt(&mut self, index: usize, x: f64, y: f64, heading: f64);
-    fn translation_wpt(&mut self, index: usize, x: f64, y: f64, heading_guess: f64);
-    fn empty_wpt(&mut self, index: usize, x_guess: f64, y_guess: f64, heading_guess: f64);
+impl Default for SwerveTrajectoryGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
-    #[allow(clippy::ptr_arg)]
-    fn sgmt_initial_guess_points(&mut self, from_index: usize, guess_points: &Vec<Pose2d>);
+impl SwerveTrajectoryGenerator {
+    pub fn new() -> SwerveTrajectoryGenerator {
+        SwerveTrajectoryGenerator {
+            generator: crate::ffi::swerve_trajectory_generator_new(),
+        }
+    }
 
-    fn wpt_linear_velocity_direction(&mut self, index: usize, angle: f64);
-    fn wpt_linear_velocity_max_magnitude(&mut self, index: usize, magnitude: f64);
-    fn wpt_angular_velocity_max_magnitude(&mut self, index: usize, angular_velocity: f64);
-    fn wpt_linear_acceleration_max_magnitude(&mut self, index: usize, magnitude: f64);
-    fn wpt_point_at(
+    pub fn set_drivetrain(&mut self, drivetrain: &crate::ffi::SwerveDrivetrain) {
+        crate::ffi::SwerveTrajectoryGenerator::set_drivetrain(self.generator.pin_mut(), drivetrain);
+    }
+
+    pub fn set_bumpers(&mut self, front: f64, left: f64, right: f64, back: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::set_bumpers(
+            self.generator.pin_mut(),
+            front,
+            left,
+            right,
+            back,
+        );
+    }
+
+    pub fn set_control_interval_counts(&mut self, counts: Vec<usize>) {
+        crate::ffi::SwerveTrajectoryGenerator::set_control_interval_counts(
+            self.generator.pin_mut(),
+            counts,
+        );
+    }
+
+    // Constraints with waypoint scope
+
+    pub fn pose_wpt(&mut self, index: usize, x: f64, y: f64, heading: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::pose_wpt(
+            self.generator.pin_mut(),
+            index,
+            x,
+            y,
+            heading,
+        );
+    }
+
+    pub fn translation_wpt(&mut self, index: usize, x: f64, y: f64, heading_guess: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::translation_wpt(
+            self.generator.pin_mut(),
+            index,
+            x,
+            y,
+            heading_guess,
+        );
+    }
+
+    pub fn empty_wpt(&mut self, index: usize, x_guess: f64, y_guess: f64, heading_guess: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::empty_wpt(
+            self.generator.pin_mut(),
+            index,
+            x_guess,
+            y_guess,
+            heading_guess,
+        );
+    }
+
+    // Segment initial guess points setter
+
+    pub fn sgmt_initial_guess_points(
+        &mut self,
+        from_index: usize,
+        guess_points: &Vec<crate::ffi::Pose2d>,
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_initial_guess_points(
+            self.generator.pin_mut(),
+            from_index,
+            guess_points,
+        );
+    }
+
+    // Constraints with waypoint scope
+
+    pub fn wpt_linear_velocity_direction(&mut self, index: usize, angle: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_linear_velocity_direction(
+            self.generator.pin_mut(),
+            index,
+            angle,
+        );
+    }
+
+    pub fn wpt_linear_velocity_max_magnitude(&mut self, index: usize, magnitude: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_linear_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            magnitude,
+        );
+    }
+
+    pub fn wpt_angular_velocity_max_magnitude(&mut self, index: usize, angular_velocity: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_angular_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            angular_velocity,
+        );
+    }
+
+    pub fn wpt_linear_acceleration_max_magnitude(&mut self, index: usize, magnitude: f64) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_linear_acceleration_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            magnitude,
+        );
+    }
+
+    pub fn wpt_point_at(
         &mut self,
         index: usize,
         field_point_x: f64,
         field_point_y: f64,
         heading_tolerance: f64,
         flip: bool,
-    );
-    fn wpt_keep_in_circle(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_point_at(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            heading_tolerance,
+            flip,
+        )
+    }
+
+    pub fn wpt_keep_in_circle(
         &mut self,
         index: usize,
         field_point_x: f64,
         field_point_y: f64,
         keep_in_radius: f64,
-    );
-    fn wpt_keep_in_polygon(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_keep_in_circle(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
+
+    pub fn wpt_keep_in_polygon(
         &mut self,
         index: usize,
         field_points_x: Vec<f64>,
         field_points_y: Vec<f64>,
-    );
-    fn wpt_keep_in_lane(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_keep_in_polygon(
+            self.generator.pin_mut(),
+            index,
+            field_points_x,
+            field_points_y,
+        );
+    }
+
+    pub fn wpt_keep_in_lane(
         &mut self,
         index: usize,
         center_line_start_x: f64,
@@ -471,51 +673,128 @@ pub trait PathBuilder: Any {
         center_line_end_x: f64,
         center_line_end_y: f64,
         tolerance: f64,
-    );
-    fn wpt_keep_out_circle(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_keep_in_lane(
+            self.generator.pin_mut(),
+            index,
+            center_line_start_x,
+            center_line_start_y,
+            center_line_end_x,
+            center_line_end_y,
+            tolerance,
+        );
+    }
+
+    pub fn wpt_keep_out_circle(
         &mut self,
         index: usize,
         field_point_x: f64,
         field_point_y: f64,
         keep_in_radius: f64,
-    );
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::wpt_keep_out_circle(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
 
-    fn sgmt_linear_velocity_direction(&mut self, from_index: usize, to_index: usize, angle: f64);
-    fn sgmt_linear_velocity_max_magnitude(
+    // Constraints with segment scope
+
+    pub fn sgmt_linear_velocity_direction(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        angle: f64,
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_linear_velocity_direction(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            angle,
+        );
+    }
+
+    pub fn sgmt_linear_velocity_max_magnitude(
         &mut self,
         from_index: usize,
         to_index: usize,
         magnitude: f64,
-    );
-    fn sgmt_angular_velocity_max_magnitude(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_linear_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            magnitude,
+        );
+    }
+
+    pub fn sgmt_angular_velocity_max_magnitude(
         &mut self,
         from_index: usize,
         to_index: usize,
         angular_velocity: f64,
-    );
-    fn sgmt_linear_acceleration_max_magnitude(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_angular_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            angular_velocity,
+        );
+    }
+
+    pub fn sgmt_linear_acceleration_max_magnitude(
         &mut self,
         from_index: usize,
         to_index: usize,
         magnitude: f64,
-    );
-    fn sgmt_keep_in_circle(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_linear_acceleration_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            magnitude,
+        );
+    }
+
+    pub fn sgmt_keep_in_circle(
         &mut self,
         from_index: usize,
         to_index: usize,
         field_point_x: f64,
         field_point_y: f64,
         keep_in_radius: f64,
-    );
-    fn sgmt_keep_in_polygon(
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_keep_in_circle(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
+
+    pub fn sgmt_keep_in_polygon(
         &mut self,
         from_index: usize,
         to_index: usize,
         field_points_x: Vec<f64>,
         field_points_y: Vec<f64>,
-    );
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_keep_in_polygon(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            field_points_x,
+            field_points_y,
+        );
+    }
+
     #[allow(clippy::too_many_arguments)]
-    fn sgmt_keep_in_lane(
+    pub fn sgmt_keep_in_lane(
         &mut self,
         from_index: usize,
         to_index: usize,
@@ -524,25 +803,35 @@ pub trait PathBuilder: Any {
         center_line_end_x: f64,
         center_line_end_y: f64,
         tolerance: f64,
-    );
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_keep_in_lane(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            center_line_start_x,
+            center_line_start_y,
+            center_line_end_x,
+            center_line_end_y,
+            tolerance,
+        )
+    }
 
-    fn sgmt_keep_out_circle(
+    pub fn sgmt_keep_out_circle(
         &mut self,
         from_index: usize,
         to_index: usize,
         x: f64,
         y: f64,
         radius: f64,
-    );
-}
-pub struct SwervePathBuilder {
-    path_builder: cxx::UniquePtr<crate::ffi::SwervePathBuilder>,
-}
-impl SwervePathBuilder {
-    pub fn new() -> SwervePathBuilder {
-        SwervePathBuilder {
-            path_builder: crate::ffi::swerve_path_builder_new(),
-        }
+    ) {
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_keep_out_circle(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            x,
+            y,
+            radius,
+        );
     }
 
     pub fn sgmt_point_at(
@@ -554,8 +843,8 @@ impl SwervePathBuilder {
         heading_tolerance: f64,
         flip: bool,
     ) {
-        crate::ffi::SwervePathBuilder::sgmt_point_at(
-            self.path_builder.pin_mut(),
+        crate::ffi::SwerveTrajectoryGenerator::sgmt_point_at(
+            self.generator.pin_mut(),
             from_index,
             to_index,
             field_point_x,
@@ -563,38 +852,6 @@ impl SwervePathBuilder {
             heading_tolerance,
             flip,
         )
-    }
-
-    pub fn set_drivetrain(&mut self, drivetrain: &crate::ffi::SwerveDrivetrain) {
-        crate::ffi::SwervePathBuilder::set_drivetrain(self.path_builder.pin_mut(), drivetrain);
-    }
-
-    ///
-    /// Generate the trajectory;
-    ///
-    /// * diagnostics: If true, prints per-iteration details of the solver to
-    ///   stdout.
-    /// * handle: A number used to identify results from this generation in the
-    ///   `add_progress_callback` callback. If `add_progress_callback` has not
-    ///   been called, this value has no significance.
-    ///
-    /// Returns a result with either the final `trajopt::SwerveTrajectory`,
-    /// or a TrajoptError if generation failed.
-    pub fn generate(
-        &self,
-        diagnostics: bool,
-        handle: i64,
-    ) -> Result<SwerveTrajectory, TrajoptError> {
-        match self.path_builder.generate(diagnostics, handle) {
-            Ok(trajectory) => Ok(trajectory),
-            Err(msg) => {
-                let what = msg.what();
-                Err(TrajoptError::from(
-                    what.parse::<i8>()
-                        .map_err(|_| TrajoptError::Unparsable(Box::from(what)))?,
-                ))
-            }
-        }
     }
 
     ///
@@ -605,327 +862,8 @@ impl SwervePathBuilder {
     ///   parameter will be an `i64` equal to the handle passed in `generate()`
     ///
     /// This function can be called multiple times to add multiple callbacks.
-    pub fn add_progress_callback(&mut self, callback: fn(SwerveTrajectory, i64)) {
-        crate::ffi::SwervePathBuilder::add_progress_callback(self.path_builder.pin_mut(), callback);
-    }
-}
-impl PathBuilder for SwervePathBuilder {
-    fn set_bumpers(&mut self, front: f64, left: f64, right: f64, back: f64) {
-        crate::ffi::SwervePathBuilder::set_bumpers(
-            self.path_builder.pin_mut(),
-            front,
-            left,
-            right,
-            back,
-        );
-    }
-
-    fn set_control_interval_counts(&mut self, counts: Vec<usize>) {
-        crate::ffi::SwervePathBuilder::set_control_interval_counts(
-            self.path_builder.pin_mut(),
-            counts,
-        );
-    }
-
-    fn pose_wpt(&mut self, index: usize, x: f64, y: f64, heading: f64) {
-        crate::ffi::SwervePathBuilder::pose_wpt(self.path_builder.pin_mut(), index, x, y, heading);
-    }
-
-    fn translation_wpt(&mut self, index: usize, x: f64, y: f64, heading_guess: f64) {
-        crate::ffi::SwervePathBuilder::translation_wpt(
-            self.path_builder.pin_mut(),
-            index,
-            x,
-            y,
-            heading_guess,
-        );
-    }
-
-    fn empty_wpt(&mut self, index: usize, x_guess: f64, y_guess: f64, heading_guess: f64) {
-        crate::ffi::SwervePathBuilder::empty_wpt(
-            self.path_builder.pin_mut(),
-            index,
-            x_guess,
-            y_guess,
-            heading_guess,
-        );
-    }
-
-    fn sgmt_initial_guess_points(
-        &mut self,
-        from_index: usize,
-        guess_points: &Vec<crate::ffi::Pose2d>,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_initial_guess_points(
-            self.path_builder.pin_mut(),
-            from_index,
-            guess_points,
-        );
-    }
-
-    fn wpt_linear_velocity_direction(&mut self, index: usize, angle: f64) {
-        crate::ffi::SwervePathBuilder::wpt_linear_velocity_direction(
-            self.path_builder.pin_mut(),
-            index,
-            angle,
-        );
-    }
-
-    fn wpt_linear_velocity_max_magnitude(&mut self, index: usize, magnitude: f64) {
-        crate::ffi::SwervePathBuilder::wpt_linear_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            magnitude,
-        );
-    }
-
-    fn wpt_angular_velocity_max_magnitude(&mut self, index: usize, angular_velocity: f64) {
-        crate::ffi::SwervePathBuilder::wpt_angular_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            angular_velocity,
-        );
-    }
-
-    fn wpt_linear_acceleration_max_magnitude(&mut self, index: usize, magnitude: f64) {
-        crate::ffi::SwervePathBuilder::wpt_linear_acceleration_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            magnitude,
-        );
-    }
-
-    fn wpt_point_at(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        heading_tolerance: f64,
-        flip: bool,
-    ) {
-        crate::ffi::SwervePathBuilder::wpt_point_at(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            heading_tolerance,
-            flip,
-        )
-    }
-
-    fn wpt_keep_in_circle(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::wpt_keep_in_circle(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn wpt_keep_in_polygon(
-        &mut self,
-        index: usize,
-        field_points_x: Vec<f64>,
-        field_points_y: Vec<f64>,
-    ) {
-        crate::ffi::SwervePathBuilder::wpt_keep_in_polygon(
-            self.path_builder.pin_mut(),
-            index,
-            field_points_x,
-            field_points_y,
-        );
-    }
-    fn wpt_keep_in_lane(
-        &mut self,
-        index: usize,
-        center_line_start_x: f64,
-        center_line_start_y: f64,
-        center_line_end_x: f64,
-        center_line_end_y: f64,
-        tolerance: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::wpt_keep_in_lane(
-            self.path_builder.pin_mut(),
-            index,
-            center_line_start_x,
-            center_line_start_y,
-            center_line_end_x,
-            center_line_end_y,
-            tolerance,
-        );
-    }
-
-    fn wpt_keep_out_circle(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::wpt_keep_out_circle(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn sgmt_linear_velocity_direction(&mut self, from_index: usize, to_index: usize, angle: f64) {
-        crate::ffi::SwervePathBuilder::sgmt_linear_velocity_direction(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            angle,
-        );
-    }
-
-    fn sgmt_linear_velocity_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        magnitude: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_linear_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            magnitude,
-        );
-    }
-
-    fn sgmt_angular_velocity_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        angular_velocity: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_angular_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            angular_velocity,
-        );
-    }
-
-    fn sgmt_linear_acceleration_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        magnitude: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_linear_acceleration_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            magnitude,
-        );
-    }
-
-    fn sgmt_keep_in_circle(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_keep_in_circle(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn sgmt_keep_in_polygon(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        field_points_x: Vec<f64>,
-        field_points_y: Vec<f64>,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_keep_in_polygon(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            field_points_x,
-            field_points_y,
-        );
-    }
-    #[allow(clippy::too_many_arguments)]
-    fn sgmt_keep_in_lane(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        center_line_start_x: f64,
-        center_line_start_y: f64,
-        center_line_end_x: f64,
-        center_line_end_y: f64,
-        tolerance: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_keep_in_lane(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            center_line_start_x,
-            center_line_start_y,
-            center_line_end_x,
-            center_line_end_y,
-            tolerance,
-        )
-    }
-
-    fn sgmt_keep_out_circle(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        x: f64,
-        y: f64,
-        radius: f64,
-    ) {
-        crate::ffi::SwervePathBuilder::sgmt_keep_out_circle(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            x,
-            y,
-            radius,
-        );
-    }
-}
-
-impl Default for SwervePathBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-pub struct DifferentialPathBuilder {
-    path_builder: cxx::UniquePtr<crate::ffi::DifferentialPathBuilder>,
-}
-
-impl DifferentialPathBuilder {
-    pub fn new() -> DifferentialPathBuilder {
-        DifferentialPathBuilder {
-            path_builder: crate::ffi::differential_path_builder_new(),
-        }
-    }
-
-    pub fn set_drivetrain(&mut self, drivetrain: &crate::ffi::DifferentialDrivetrain) {
-        crate::ffi::DifferentialPathBuilder::set_drivetrain(
-            self.path_builder.pin_mut(),
-            drivetrain,
-        );
+    pub fn add_callback(&mut self, callback: fn(SwerveTrajectory, i64)) {
+        crate::ffi::SwerveTrajectoryGenerator::add_callback(self.generator.pin_mut(), callback);
     }
 
     ///
@@ -934,18 +872,17 @@ impl DifferentialPathBuilder {
     /// * diagnostics: If true, prints per-iteration details of the solver to
     ///   stdout.
     /// * handle: A number used to identify results from this generation in the
-    ///   `add_progress_callback` callback. If `add_progress_callback` has not
-    ///   been called, this value has no significance.
+    ///   `add_callback` callback. If `add_callback` has not been called, this
+    ///   value has no significance.
     ///
-    /// Returns a result with either the final
-    /// `trajopt::DifferentialTrajectory`, or TrajoptError
-    /// generation failed.
+    /// Returns a result with either the final `trajopt::SwerveTrajectory`,
+    /// or a TrajoptError if generation failed.
     pub fn generate(
         &self,
         diagnostics: bool,
         handle: i64,
-    ) -> Result<DifferentialTrajectory, TrajoptError> {
-        match self.path_builder.generate(diagnostics, handle) {
+    ) -> Result<SwerveTrajectory, TrajoptError> {
+        match self.generator.generate(diagnostics, handle) {
             Ok(trajectory) => Ok(trajectory),
             Err(msg) => {
                 let what = msg.what();
@@ -956,6 +893,345 @@ impl DifferentialPathBuilder {
             }
         }
     }
+}
+
+pub struct DifferentialTrajectoryGenerator {
+    generator: cxx::UniquePtr<crate::ffi::DifferentialTrajectoryGenerator>,
+}
+
+impl Default for DifferentialTrajectoryGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DifferentialTrajectoryGenerator {
+    pub fn new() -> DifferentialTrajectoryGenerator {
+        DifferentialTrajectoryGenerator {
+            generator: crate::ffi::differential_trajectory_generator_new(),
+        }
+    }
+
+    pub fn set_drivetrain(&mut self, drivetrain: &crate::ffi::DifferentialDrivetrain) {
+        crate::ffi::DifferentialTrajectoryGenerator::set_drivetrain(
+            self.generator.pin_mut(),
+            drivetrain,
+        );
+    }
+
+    pub fn set_bumpers(&mut self, front: f64, left: f64, right: f64, back: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::set_bumpers(
+            self.generator.pin_mut(),
+            front,
+            left,
+            right,
+            back,
+        );
+    }
+
+    pub fn set_control_interval_counts(&mut self, counts: Vec<usize>) {
+        crate::ffi::DifferentialTrajectoryGenerator::set_control_interval_counts(
+            self.generator.pin_mut(),
+            counts,
+        );
+    }
+
+    // Pose constraints
+
+    pub fn pose_wpt(&mut self, index: usize, x: f64, y: f64, heading: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::pose_wpt(
+            self.generator.pin_mut(),
+            index,
+            x,
+            y,
+            heading,
+        );
+    }
+
+    pub fn translation_wpt(&mut self, index: usize, x: f64, y: f64, heading_guess: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::translation_wpt(
+            self.generator.pin_mut(),
+            index,
+            x,
+            y,
+            heading_guess,
+        );
+    }
+
+    pub fn empty_wpt(&mut self, index: usize, x_guess: f64, y_guess: f64, heading_guess: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::empty_wpt(
+            self.generator.pin_mut(),
+            index,
+            x_guess,
+            y_guess,
+            heading_guess,
+        );
+    }
+
+    // Segment initial guess points setter
+
+    pub fn sgmt_initial_guess_points(
+        &mut self,
+        from_index: usize,
+        guess_points: &Vec<crate::ffi::Pose2d>,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_initial_guess_points(
+            self.generator.pin_mut(),
+            from_index,
+            guess_points,
+        );
+    }
+
+    // Constraints with waypoint scope
+
+    pub fn wpt_linear_velocity_direction(&mut self, index: usize, angle: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_linear_velocity_direction(
+            self.generator.pin_mut(),
+            index,
+            angle,
+        );
+    }
+
+    pub fn wpt_linear_velocity_max_magnitude(&mut self, index: usize, magnitude: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_linear_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            magnitude,
+        );
+    }
+
+    pub fn wpt_angular_velocity_max_magnitude(&mut self, index: usize, angular_velocity: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_angular_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            angular_velocity,
+        );
+    }
+
+    pub fn wpt_linear_acceleration_max_magnitude(&mut self, index: usize, magnitude: f64) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_linear_acceleration_max_magnitude(
+            self.generator.pin_mut(),
+            index,
+            magnitude,
+        );
+    }
+
+    pub fn wpt_point_at(
+        &mut self,
+        index: usize,
+        field_point_x: f64,
+        field_point_y: f64,
+        heading_tolerance: f64,
+        flip: bool,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_point_at(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            heading_tolerance,
+            flip,
+        )
+    }
+
+    pub fn wpt_keep_in_circle(
+        &mut self,
+        index: usize,
+        field_point_x: f64,
+        field_point_y: f64,
+        keep_in_radius: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_keep_in_circle(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
+
+    pub fn wpt_keep_in_polygon(
+        &mut self,
+        index: usize,
+        field_points_x: Vec<f64>,
+        field_points_y: Vec<f64>,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_keep_in_polygon(
+            self.generator.pin_mut(),
+            index,
+            field_points_x,
+            field_points_y,
+        );
+    }
+
+    pub fn wpt_keep_in_lane(
+        &mut self,
+        index: usize,
+        center_line_start_x: f64,
+        center_line_start_y: f64,
+        center_line_end_x: f64,
+        center_line_end_y: f64,
+        tolerance: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_keep_in_lane(
+            self.generator.pin_mut(),
+            index,
+            center_line_start_x,
+            center_line_start_y,
+            center_line_end_x,
+            center_line_end_y,
+            tolerance,
+        );
+    }
+
+    pub fn wpt_keep_out_circle(
+        &mut self,
+        index: usize,
+        field_point_x: f64,
+        field_point_y: f64,
+        keep_in_radius: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::wpt_keep_out_circle(
+            self.generator.pin_mut(),
+            index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
+
+    // Constraints with segment scope
+
+    pub fn sgmt_linear_velocity_direction(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        angle: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_linear_velocity_direction(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            angle,
+        );
+    }
+
+    pub fn sgmt_linear_velocity_max_magnitude(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        magnitude: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_linear_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            magnitude,
+        );
+    }
+
+    pub fn sgmt_angular_velocity_max_magnitude(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        angular_velocity: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_angular_velocity_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            angular_velocity,
+        );
+    }
+
+    pub fn sgmt_linear_acceleration_max_magnitude(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        magnitude: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_linear_acceleration_max_magnitude(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            magnitude,
+        );
+    }
+
+    pub fn sgmt_keep_in_circle(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        field_point_x: f64,
+        field_point_y: f64,
+        keep_in_radius: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_keep_in_circle(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            field_point_x,
+            field_point_y,
+            keep_in_radius,
+        )
+    }
+
+    pub fn sgmt_keep_in_polygon(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        field_points_x: Vec<f64>,
+        field_points_y: Vec<f64>,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_keep_in_polygon(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            field_points_x,
+            field_points_y,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn sgmt_keep_in_lane(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        center_line_start_x: f64,
+        center_line_start_y: f64,
+        center_line_end_x: f64,
+        center_line_end_y: f64,
+        tolerance: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_keep_in_lane(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            center_line_start_x,
+            center_line_start_y,
+            center_line_end_x,
+            center_line_end_y,
+            tolerance,
+        )
+    }
+
+    pub fn sgmt_keep_out_circle(
+        &mut self,
+        from_index: usize,
+        to_index: usize,
+        x: f64,
+        y: f64,
+        radius: f64,
+    ) {
+        crate::ffi::DifferentialTrajectoryGenerator::sgmt_keep_out_circle(
+            self.generator.pin_mut(),
+            from_index,
+            to_index,
+            x,
+            y,
+            radius,
+        );
+    }
 
     ///
     /// Add a callback that will be called on each iteration of the solver.
@@ -965,325 +1241,46 @@ impl DifferentialPathBuilder {
     ///   parameter will be an `i64` equal to the handle passed in `generate()`
     ///
     /// This function can be called multiple times to add multiple callbacks.
-    pub fn add_progress_callback(&mut self, callback: fn(DifferentialTrajectory, i64)) {
-        crate::ffi::DifferentialPathBuilder::add_progress_callback(
-            self.path_builder.pin_mut(),
+    pub fn add_callback(&mut self, callback: fn(DifferentialTrajectory, i64)) {
+        crate::ffi::DifferentialTrajectoryGenerator::add_callback(
+            self.generator.pin_mut(),
             callback,
         );
     }
-}
-impl PathBuilder for DifferentialPathBuilder {
-    fn set_bumpers(&mut self, front: f64, left: f64, right: f64, back: f64) {
-        crate::ffi::DifferentialPathBuilder::set_bumpers(
-            self.path_builder.pin_mut(),
-            front,
-            left,
-            right,
-            back,
-        );
-    }
 
-    fn set_control_interval_counts(&mut self, counts: Vec<usize>) {
-        crate::ffi::DifferentialPathBuilder::set_control_interval_counts(
-            self.path_builder.pin_mut(),
-            counts,
-        );
-    }
-
-    fn pose_wpt(&mut self, index: usize, x: f64, y: f64, heading: f64) {
-        crate::ffi::DifferentialPathBuilder::pose_wpt(
-            self.path_builder.pin_mut(),
-            index,
-            x,
-            y,
-            heading,
-        );
-    }
-
-    fn translation_wpt(&mut self, index: usize, x: f64, y: f64, heading_guess: f64) {
-        crate::ffi::DifferentialPathBuilder::translation_wpt(
-            self.path_builder.pin_mut(),
-            index,
-            x,
-            y,
-            heading_guess,
-        );
-    }
-
-    fn empty_wpt(&mut self, index: usize, x_guess: f64, y_guess: f64, heading_guess: f64) {
-        crate::ffi::DifferentialPathBuilder::empty_wpt(
-            self.path_builder.pin_mut(),
-            index,
-            x_guess,
-            y_guess,
-            heading_guess,
-        );
-    }
-
-    fn sgmt_initial_guess_points(
-        &mut self,
-        from_index: usize,
-        guess_points: &Vec<crate::ffi::Pose2d>,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_initial_guess_points(
-            self.path_builder.pin_mut(),
-            from_index,
-            guess_points,
-        );
-    }
-
-    fn wpt_linear_velocity_direction(&mut self, index: usize, angle: f64) {
-        crate::ffi::DifferentialPathBuilder::wpt_linear_velocity_direction(
-            self.path_builder.pin_mut(),
-            index,
-            angle,
-        );
-    }
-
-    fn wpt_linear_velocity_max_magnitude(&mut self, index: usize, magnitude: f64) {
-        crate::ffi::DifferentialPathBuilder::wpt_linear_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            magnitude,
-        );
-    }
-
-    fn wpt_angular_velocity_max_magnitude(&mut self, index: usize, angular_velocity: f64) {
-        crate::ffi::DifferentialPathBuilder::wpt_angular_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            angular_velocity,
-        );
-    }
-
-    fn wpt_linear_acceleration_max_magnitude(&mut self, index: usize, magnitude: f64) {
-        crate::ffi::DifferentialPathBuilder::wpt_linear_acceleration_max_magnitude(
-            self.path_builder.pin_mut(),
-            index,
-            magnitude,
-        );
-    }
-
-    fn wpt_point_at(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        heading_tolerance: f64,
-        flip: bool,
-    ) {
-        crate::ffi::DifferentialPathBuilder::wpt_point_at(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            heading_tolerance,
-            flip,
-        )
-    }
-
-    fn wpt_keep_in_circle(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::wpt_keep_in_circle(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn wpt_keep_in_polygon(
-        &mut self,
-        index: usize,
-        field_points_x: Vec<f64>,
-        field_points_y: Vec<f64>,
-    ) {
-        crate::ffi::DifferentialPathBuilder::wpt_keep_in_polygon(
-            self.path_builder.pin_mut(),
-            index,
-            field_points_x,
-            field_points_y,
-        );
-    }
-    fn wpt_keep_in_lane(
-        &mut self,
-        index: usize,
-        center_line_start_x: f64,
-        center_line_start_y: f64,
-        center_line_end_x: f64,
-        center_line_end_y: f64,
-        tolerance: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::wpt_keep_in_lane(
-            self.path_builder.pin_mut(),
-            index,
-            center_line_start_x,
-            center_line_start_y,
-            center_line_end_x,
-            center_line_end_y,
-            tolerance,
-        );
-    }
-
-    fn wpt_keep_out_circle(
-        &mut self,
-        index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::wpt_keep_out_circle(
-            self.path_builder.pin_mut(),
-            index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn sgmt_linear_velocity_direction(&mut self, from_index: usize, to_index: usize, angle: f64) {
-        crate::ffi::DifferentialPathBuilder::sgmt_linear_velocity_direction(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            angle,
-        );
-    }
-
-    fn sgmt_linear_velocity_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        magnitude: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_linear_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            magnitude,
-        );
-    }
-
-    fn sgmt_angular_velocity_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        angular_velocity: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_angular_velocity_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            angular_velocity,
-        );
-    }
-
-    fn sgmt_linear_acceleration_max_magnitude(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        magnitude: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_linear_acceleration_max_magnitude(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            magnitude,
-        );
-    }
-
-    fn sgmt_keep_in_circle(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        field_point_x: f64,
-        field_point_y: f64,
-        keep_in_radius: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_keep_in_circle(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            field_point_x,
-            field_point_y,
-            keep_in_radius,
-        )
-    }
-
-    fn sgmt_keep_in_polygon(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        field_points_x: Vec<f64>,
-        field_points_y: Vec<f64>,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_keep_in_polygon(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            field_points_x,
-            field_points_y,
-        );
-    }
-    #[allow(clippy::too_many_arguments)]
-    fn sgmt_keep_in_lane(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        center_line_start_x: f64,
-        center_line_start_y: f64,
-        center_line_end_x: f64,
-        center_line_end_y: f64,
-        tolerance: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_keep_in_lane(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            center_line_start_x,
-            center_line_start_y,
-            center_line_end_x,
-            center_line_end_y,
-            tolerance,
-        )
-    }
-
-    fn sgmt_keep_out_circle(
-        &mut self,
-        from_index: usize,
-        to_index: usize,
-        x: f64,
-        y: f64,
-        radius: f64,
-    ) {
-        crate::ffi::DifferentialPathBuilder::sgmt_keep_out_circle(
-            self.path_builder.pin_mut(),
-            from_index,
-            to_index,
-            x,
-            y,
-            radius,
-        );
-    }
-}
-
-impl Default for DifferentialPathBuilder {
-    fn default() -> Self {
-        Self::new()
+    ///
+    /// Generate the trajectory;
+    ///
+    /// * diagnostics: If true, prints per-iteration details of the solver to
+    ///   stdout.
+    /// * handle: A number used to identify results from this generation in the
+    ///   `add_callback` callback. If `add_callback` has not been called, this
+    ///   value has no significance.
+    ///
+    /// Returns a result with either the final
+    /// `trajopt::DifferentialTrajectory`, or TrajoptError
+    /// generation failed.
+    pub fn generate(
+        &self,
+        diagnostics: bool,
+        handle: i64,
+    ) -> Result<DifferentialTrajectory, TrajoptError> {
+        match self.generator.generate(diagnostics, handle) {
+            Ok(trajectory) => Ok(trajectory),
+            Err(msg) => {
+                let what = msg.what();
+                Err(TrajoptError::from(
+                    what.parse::<i8>()
+                        .map_err(|_| TrajoptError::Unparsable(Box::from(what)))?,
+                ))
+            }
+        }
     }
 }
 
 pub fn cancel_all() {
     crate::ffi::cancel_all();
 }
-
-use std::any::Any;
 
 use error::TrajoptError;
 pub use ffi::DifferentialDrivetrain;

--- a/trajoptlib/test/src/DifferentialPathBuilderTest.cpp
+++ b/trajoptlib/test/src/DifferentialPathBuilderTest.cpp
@@ -18,7 +18,7 @@ TEST_CASE("DifferentialPathBuilder - Linear initial guess",
 
   path.WptInitialGuessPoint(2, Pose2d{5.0, 0.0, 0.0});  // at 2
 
-  path.ControlIntervalCounts({3, 2});
+  path.SetControlIntervalCounts({3, 2});
 
   std::vector<double> result = path.CalculateInitialGuess().x;
   std::vector<double> expected = {0.0, 1.0, 2.0, 1.0, 3.0, 5.0};

--- a/trajoptlib/test/src/SwervePathBuilderTest.cpp
+++ b/trajoptlib/test/src/SwervePathBuilderTest.cpp
@@ -17,7 +17,7 @@ TEST_CASE("SwervePathBuilder - Linear initial guess", "[SwervePathBuilder]") {
 
   path.WptInitialGuessPoint(2, Pose2d{5.0, 0.0, 0.0});  // at 2
 
-  path.ControlIntervalCounts({3, 2});
+  path.SetControlIntervalCounts({3, 2});
 
   std::vector<double> result = path.CalculateInitialGuess().x;
   std::vector<double> expected = {0.0, 1.0, 2.0, 1.0, 3.0, 5.0};


### PR DESCRIPTION
The Rust *PathBuilder classes were renamed to *TrajectoryGenerator to better reflect what they're used for.