### PR TITLE
[choreolib] Remove Choreo prefix from typedef

### DIFF
--- a/choreolib/src/main/native/include/choreo/auto/AutoFactory.h
+++ b/choreolib/src/main/native/include/choreo/auto/AutoFactory.h
@@ -131,7 +131,7 @@ class AutoFactory {
    * @param trajectoryLogger Choreo::CreateAutoFactory()
    */
   AutoFactory(std::function<frc::Pose2d()> poseSupplier,
-              ChoreoControllerFunction<SampleType> controller,
+              ControllerFunction<SampleType> controller,
               std::function<bool()> mirrorTrajectory,
               const frc2::Subsystem& driveSubsystem, AutoBindings bindings,
               std::optional<TrajectoryLogger> trajectoryLogger)
@@ -236,7 +236,7 @@ class AutoFactory {
 
  private:
   std::function<frc::Pose2d()> poseSupplier;
-  ChoreoControllerFunction<SampleType> controller;
+  ControllerFunction<SampleType> controller;
   std::function<bool()> mirrorTrajectory;
   const frc2::Subsystem& driveSubsystem;
   AutoBindings autoBindings{};

--- a/choreolib/src/main/native/include/choreo/auto/AutoTrajectory.h
+++ b/choreolib/src/main/native/include/choreo/auto/AutoTrajectory.h
@@ -22,7 +22,7 @@
 namespace choreo {
 
 template <choreo::TrajectorySample SampleType>
-using ChoreoControllerFunction = std::function<void(frc::Pose2d, SampleType)>;
+using ControllerFunction = std::function<void(frc::Pose2d, SampleType)>;
 
 using TrajectoryLogger = std::function<void(frc::Pose2d, bool)>;
 
@@ -55,7 +55,7 @@ class AutoTrajectory {
   AutoTrajectory(std::string_view name,
                  const choreo::Trajectory<SampleType>& trajectory,
                  std::function<frc::Pose2d()> poseSupplier,
-                 ChoreoControllerFunction<SampleType> controller,
+                 ControllerFunction<SampleType> controller,
                  std::function<bool()> mirrorTrajectory,
                  std::optional<TrajectoryLogger> trajectoryLogger,
                  const frc2::Subsystem& driveSubsystem, frc::EventLoop* loop,
@@ -330,7 +330,7 @@ class AutoTrajectory {
   std::string name;
   const choreo::Trajectory<SampleType>& trajectory;
   std::function<frc::Pose2d()> poseSupplier;
-  ChoreoControllerFunction<SampleType> controller;
+  ControllerFunction<SampleType> controller;
   std::function<bool()> mirrorTrajectory;
   std::optional<TrajectoryLogger> trajectoryLogger;
   const frc2::Subsystem& driveSubsystem;


### PR DESCRIPTION
The enclosing choreo namespace makes it redundant.