### PR TITLE
Use marker name for triggers; change spec to prepare for timestamp-range markers.

### DIFF
--- a/choreolib/py/choreo/__init__.py
+++ b/choreolib/py/choreo/__init__.py
@@ -41,9 +41,9 @@ def load_differential_trajectory_string(
     splits = [int(split) for split in data["trajectory"]["splits"]]
     events = [
         EventMarker(
-            float(event["data"]["offset"]["val"])
-            + float(event["data"]["targetTimestamp"]),
-            event["event"]["data"]["event"],
+            float(event["from"]["offset"]["val"])
+            + float(event["from"]["targetTimestamp"]),
+            event["name"],
         )
         for event in data["events"]
     ]
@@ -96,9 +96,9 @@ def load_swerve_trajectory_string(trajectory_json_string: str) -> SwerveTrajecto
     splits = [int(split) for split in data["trajectory"]["splits"]]
     events = [
         EventMarker(
-            float(event["data"]["offset"]["val"])
-            + float(event["data"]["targetTimestamp"]),
-            event["event"]["data"]["event"],
+            float(event["from"]["offset"]["val"])
+            + float(event["from"]["targetTimestamp"]),
+            event["name"],
         )
         for event in data["events"]
     ]

--- a/choreolib/py/choreo/test/choreolib_test.py
+++ b/choreolib/py/choreo/test/choreolib_test.py
@@ -38,9 +38,8 @@ TRAJECTORY = """
   "forcesAvailable":false
  },
  "events":[
-  {"data":{"name":"Marker", "target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":{"type":"choreolib", "data":{"event":"testEvent"}}}
- ],
- "pplib_commands":[]
+  {"name":"testEvent", "from":{"target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":null}
+ ]
 }
 """
 

--- a/choreolib/py/choreo/test/resources/swerve_test.traj
+++ b/choreolib/py/choreo/test/resources/swerve_test.traj
@@ -47,6 +47,6 @@
   "splits":[],
   "forcesAvailable":false
  },
- "events":[{"data":{"name":"Marker", "target":1, "targetTimestamp":1.3926677138988457, "offset":{"exp":"-1 s", "val":-1.0}}, "event":{"type":"choreolib", "data":{"event":"testEvent"}}}],
+ "events":[{"name":"testEvent", "from":{"target":1, "targetTimestamp":1.3926677138988457, "offset":{"exp":"-1 s", "val":-1.0}}, "event":null}],
  "pplib_commands":[]
 }

--- a/choreolib/src/main/java/choreo/trajectory/EventMarker.java
+++ b/choreolib/src/main/java/choreo/trajectory/EventMarker.java
@@ -34,26 +34,19 @@ public class EventMarker {
       try {
         var targetTimestamp =
             json.getAsJsonObject()
-                .get("data")
+                .get("from")
                 .getAsJsonObject()
                 .get("targetTimestamp")
                 .getAsDouble();
         var offset =
             json.getAsJsonObject()
-                .get("data")
+                .get("from")
                 .getAsJsonObject()
                 .get("offset")
                 .getAsJsonObject()
                 .get("val")
                 .getAsDouble();
-        var event =
-            json.getAsJsonObject()
-                .get("event")
-                .getAsJsonObject()
-                .get("data")
-                .getAsJsonObject()
-                .get("event")
-                .getAsString();
+        var event = json.getAsJsonObject().get("name").getAsString();
 
         return new EventMarker(targetTimestamp + offset, event);
       } catch (IllegalStateException e) {

--- a/choreolib/src/main/native/cpp/choreo/trajectory/EventMarker.cpp
+++ b/choreolib/src/main/native/cpp/choreo/trajectory/EventMarker.cpp
@@ -15,7 +15,7 @@ void choreo::to_json(wpi::json& json, const EventMarker& event) {
 
 void choreo::from_json(const wpi::json& json, EventMarker& event) {
   event.timestamp =
-      units::second_t{json.at("data").at("offset").at("val").get<double>() +
-                      json.at("data").at("targetTimestamp").get<double>()};
-  event.event = json.at("event").at("data").at("event").get<std::string>();
+      units::second_t{json.at("from").at("offset").at("val").get<double>() +
+                      json.at("from").at("targetTimestamp").get<double>()};
+  event.event = json.at("name").get<std::string>();
 }

--- a/choreolib/src/test/java/choreo/ChoreoTests.java
+++ b/choreolib/src/test/java/choreo/ChoreoTests.java
@@ -51,9 +51,8 @@ public class ChoreoTests {
   "forcesAvailable":false
  },
  "events":[
-  {"data":{"name":"Marker", "target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":{"type":"choreolib", "data":{"event":"testEvent"}}}
- ],
- "pplib_commands":[]
+  {"name":"testEvent", "from":{ "target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":null}
+ ]
 }
 """;
 

--- a/choreolib/src/test/native/cpp/TrajectoryFileTests.cpp
+++ b/choreolib/src/test/native/cpp/TrajectoryFileTests.cpp
@@ -47,9 +47,8 @@ constexpr std::string_view swerveTrajectoryString =
   "forcesAvailable":false
  },
  "events":[
-  {"data":{"name":"Marker", "target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":{"type":"choreolib", "data":{"event":"testEvent"}}}
- ],
- "pplib_commands":[]
+  {"name":"testEvent", "from":{"target":0, "targetTimestamp":0, "offset":{"exp":"0 s", "val":0.0}}, "event":null}
+ ]
 })";
 
 const wpi::json swerveTrajectoryJson = wpi::json::parse(swerveTrajectoryString);

--- a/src-core/src/spec/trajectory.rs
+++ b/src-core/src/spec/trajectory.rs
@@ -418,12 +418,7 @@ pub struct TrajectoryFile {
     pub trajectory: Trajectory,
     /// The choreo events.
     #[serde(default)]
-    pub events: Vec<ChoreolibEventMarker>,
-    /// The pplib commands to execute.
-    /// This is a compatibility layer for working with
-    /// the path planner library.
-    #[serde(default)]
-    pub pplib_commands: Vec<PplibEventMarker>,
+    pub events: Vec<EventMarker>,
 }
 
 impl TrajectoryFile {
@@ -442,7 +437,6 @@ impl TrajectoryFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventMarkerData {
-    pub name: String,
     pub target: Option<usize>,
     pub target_timestamp: Option<f64>,
     pub offset: Expr,
@@ -450,16 +444,10 @@ pub struct EventMarkerData {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ChoreolibEventMarker {
-    data: EventMarkerData,
-    event: ChoreolibEvent,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PplibEventMarker {
-    data: EventMarkerData,
-    event: PplibCommand,
+pub struct EventMarker {
+    pub name: String,
+    pub from: EventMarkerData,
+    pub event: Option<PplibCommand>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -484,11 +472,4 @@ pub enum PplibCommand {
     Deadline {
         commands: Vec<PplibCommand>,
     },
-}
-
-// single-case enum so that it matches the serialization from above
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", tag = "type", content = "data")]
-pub enum ChoreolibEvent {
-    Choreolib { event: String },
 }

--- a/src/components/config/eventmarker/CommandDraggable.tsx
+++ b/src/components/config/eventmarker/CommandDraggable.tsx
@@ -92,7 +92,7 @@ class CommandDraggable extends Component<Props, State> {
             onChange={(e) => command.setType(e.target.value as CommandType)}
           >
             {CommandUIData.map((data) => {
-              if (data.id === "choreolib" && this.props.parent !== undefined) {
+              if (data.id === "none" && this.props.parent !== undefined) {
                 return undefined;
               }
 
@@ -122,29 +122,6 @@ class CommandDraggable extends Component<Props, State> {
               onKeyDown={(e) => {
                 if (e.key == "Enter") {
                   this.nameInputRef.current?.blur();
-                }
-              }}
-            ></TextField>
-          )}
-          {command.isChoreolib && (
-            <TextField
-              inputRef={this.eventInputRef}
-              sx={{
-                marginLeft: "1ch",
-                ".MuiInput-input": {
-                  paddingBottom: "0px"
-                }
-              }}
-              fullWidth
-              variant="standard"
-              placeholder="Event"
-              value={command.event ?? ""}
-              size="small"
-              onClick={(e) => e.stopPropagation()}
-              onChange={(e) => command.setEvent(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key == "Enter") {
-                  this.eventInputRef.current?.blur();
                 }
               }}
             ></TextField>

--- a/src/components/config/eventmarker/EventMarkerConfigPanel.tsx
+++ b/src/components/config/eventmarker/EventMarkerConfigPanel.tsx
@@ -68,7 +68,7 @@ class EventMarkerConfigPanel extends Component<Props, State> {
   }
   render() {
     const marker = this.props.marker;
-    const data = marker.data;
+    const data = marker.from;
     let startIndex = (data.getTargetIndex() ?? -0.5) + 1;
     const points = this.props.points;
     const pointcount = points.length;
@@ -125,8 +125,8 @@ class EventMarkerConfigPanel extends Component<Props, State> {
 
           <TextField
             inputRef={this.nameInputRef}
-            value={data.name}
-            onChange={(e) => data.setName(e.target.value)}
+            value={marker.name}
+            onChange={(e) => marker.setName(e.target.value)}
             variant="standard"
             size="small"
             placeholder="Marker Name"

--- a/src/components/field/PathAnimationSlider.tsx
+++ b/src/components/field/PathAnimationSlider.tsx
@@ -69,11 +69,11 @@ class PathAnimationSlider extends Component<Props, State> {
                   })
                   .concat(
                     activePath.markers.flatMap((marker: IEventMarkerStore) => {
-                      if (marker.data.timestamp === undefined) {
+                      if (marker.from.timestamp === undefined) {
                         return [];
                       }
                       return {
-                        value: marker.data.timestamp,
+                        value: marker.from.timestamp,
                         label: (
                           <span>
                             <Room

--- a/src/components/field/svg/FieldEventMarkerAddLayer.tsx
+++ b/src/components/field/svg/FieldEventMarkerAddLayer.tsx
@@ -30,7 +30,7 @@ class FieldConstraintsAddLayer extends Component<Props, State> {
               onClick={() => {
                 const newMarker = activePath.addEventMarker();
 
-                newMarker.data.setTarget({ uuid: point.uuid });
+                newMarker.from.setTarget({ uuid: point.uuid });
                 // TODO set direct timestamp if trajectory not stale
                 doc.setSelectedSidebarItem(newMarker);
               }}

--- a/src/components/field/svg/FieldEventMarkers.tsx
+++ b/src/components/field/svg/FieldEventMarkers.tsx
@@ -50,10 +50,10 @@ class FieldEventMarkers extends Component<Props, State> {
     const path = doc.pathlist.activePath;
     const markers = path.markers;
     return markers.flatMap((marker) => {
-      if (marker.data.timestamp === undefined) {
+      if (marker.from.timestamp === undefined) {
         return [];
       }
-      const marked = sample(marker.data.timestamp, path.trajectory.samples);
+      const marked = sample(marker.from.timestamp, path.trajectory.samples);
       return (
         <FieldEventMarker
           key={marker.uuid}

--- a/src/components/sidebar/SidebarEventMarker.tsx
+++ b/src/components/sidebar/SidebarEventMarker.tsx
@@ -47,9 +47,9 @@ class SidebarMarker extends Component<Props, State> {
           className={styles.SidebarLabel}
           style={{ display: "grid", gridTemplateColumns: "1fr auto auto" }}
         >
-          <Tooltip disableInteractive title={this.props.marker.data.name}>
+          <Tooltip disableInteractive title={this.props.marker.name}>
             <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-              {this.props.marker.data.name}
+              {this.props.marker.name}
             </span>
           </Tooltip>
           {/* {!isInSameSegment || marker.data.getTargetIndex() === undefined ? (
@@ -63,11 +63,11 @@ class SidebarMarker extends Component<Props, State> {
             <span></span>
           )} */}
           <span>
-            <span>{this.waypointIDToText(this.props.marker.data.target)} </span>
+            <span>{this.waypointIDToText(this.props.marker.from.target)} </span>
             <span style={{}}>
               (
-              {(this.props.marker.data.offset.value < 0 ? "" : "+") +
-                this.props.marker.data.offset.value.toFixed(2) +
+              {(this.props.marker.from.offset.value < 0 ? "" : "+") +
+                this.props.marker.from.offset.value.toFixed(2) +
                 " s"}
               )
             </span>

--- a/src/document/2025/v2025_0_0.ts
+++ b/src/document/2025/v2025_0_0.ts
@@ -137,8 +137,7 @@ export interface Trajectory {
   params: ChoreoPath<Expr>;
   snapshot: ChoreoPath<number>;
   trajectory: Output;
-  events: EventMarker<ChoreolibEvent>[];
-  pplibCommands: EventMarker<PplibCommand>[];
+  events: EventMarker[];
 }
 
 export type GroupCommand = {
@@ -159,15 +158,8 @@ export type NamedCommand = {
     name: string | null;
   };
 };
-export type ChoreolibEvent = {
-  type: "choreolib";
-  data: {
-    event: string | null;
-  };
-};
 
 export type EventMarkerData = {
-  name: string;
   target: WaypointIDX | undefined;
   offset: Expr;
   /**
@@ -176,8 +168,9 @@ export type EventMarkerData = {
   targetTimestamp: number | undefined;
 };
 export type PplibCommand = WaitCommand | GroupCommand | NamedCommand;
-export type Command = PplibCommand | ChoreolibEvent;
-export interface EventMarker<C extends Command> {
-  data: EventMarkerData;
-  event: C;
+export type Command = PplibCommand | undefined;
+export interface EventMarker {
+  name: string;
+  from: EventMarkerData;
+  event: Command;
 }

--- a/src/document/CommandStore.tsx
+++ b/src/document/CommandStore.tsx
@@ -8,7 +8,6 @@ import {
 } from "mobx-state-tree";
 import { moveItem } from "mobx-utils";
 import {
-  ChoreolibEvent,
   Command,
   Expr,
   GroupCommand,
@@ -19,7 +18,7 @@ import { Env } from "./DocumentManager";
 import { ExpressionStore } from "./ExpressionStore";
 
 export type CommandGroupType = "sequential" | "parallel" | "deadline" | "race";
-export type CommandType = CommandGroupType | "wait" | "named" | "choreolib";
+export type CommandType = CommandGroupType | "wait" | "named" | "none";
 export const CommandTypeNames = {
   sequential: { id: "sequential", name: "Sequence" },
   parallel: { id: "parallel", name: "Parallel" },
@@ -27,11 +26,11 @@ export const CommandTypeNames = {
   race: { id: "race", name: "Race" },
   wait: { id: "wait", name: "Wait" },
   named: { id: "named", name: "Named" },
-  choreolib: { id: "choreolib", name: "Choreolib" }
+  none: { id: "none", name: "None" }
 };
 export const CommandUIData = Object.values(CommandTypeNames);
 export function commandIsNamed(command: Command): command is NamedCommand {
-  return command.type === "named";
+  return command !== undefined && command.type === "named";
 }
 export function commandTypeIsGroup(type: CommandType) {
   return (
@@ -42,15 +41,10 @@ export function commandTypeIsGroup(type: CommandType) {
   );
 }
 export function commandIsGroup(command: Command): command is GroupCommand {
-  return commandTypeIsGroup(command.type);
+  return command !== undefined && commandTypeIsGroup(command.type);
 }
 export function commandIsWait(command: Command): command is WaitCommand {
-  return command.type === "wait";
-}
-export function commandIsChoreolib(
-  command: Command
-): command is ChoreolibEvent {
-  return command.type === "choreolib";
+  return command !== undefined && command.type === "wait";
 }
 export const CommandStore = types
   .model("CommandStore", {
@@ -61,20 +55,19 @@ export const CommandStore = types
       types.literal("race"),
       types.literal("wait"),
       types.literal("named"),
-      types.literal("choreolib")
+      types.literal("none")
     ),
     commands: types.array(types.late((): IAnyType => CommandStore)),
     time: ExpressionStore,
     name: types.maybeNull(types.string),
-    event: types.maybeNull(types.string),
     uuid: types.identifier
   })
   .views((self) => ({
     get isGroup(): boolean {
       return commandTypeIsGroup(self.type);
     },
-    get isChoreolib(): boolean {
-      return self.type === "choreolib";
+    get isNone(): boolean {
+      return self.type === "none";
     },
     get isNamed(): boolean {
       return self.type === "named";
@@ -99,13 +92,8 @@ export const CommandStore = types
             waitTime: self.time.serialize
           }
         };
-      } else if (self.isChoreolib) {
-        return {
-          type: "choreolib",
-          data: {
-            event: self.event
-          }
-        };
+      } else if (self.isNone) {
+        return undefined;
       } else {
         return {
           type: self.type as CommandGroupType,
@@ -120,14 +108,15 @@ export const CommandStore = types
     deserialize(ser: Command) {
       self.commands.clear();
       self.name = "";
-      self.event = "";
+      if (ser === undefined) {
+        self.type = "none";
+        return;
+      }
       self.type = ser.type;
       if (commandIsNamed(ser)) {
         self.name = ser.data.name;
       } else if (commandIsWait(ser)) {
         self.time.deserialize(ser.data.waitTime);
-      } else if (commandIsChoreolib(ser)) {
-        self.event = ser.data.event;
       } else {
         ser.data.commands.forEach((c) => {
           const command: ICommandStore =
@@ -145,9 +134,6 @@ export const CommandStore = types
     },
     setName(name: string) {
       self.name = name;
-    },
-    setEvent(event: string) {
-      self.event = event;
     },
     addSubCommand() {
       // TODO add subcommand

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -15,7 +15,6 @@ import "react-toastify/dist/ReactToastify.min.css";
 import LocalStorageKeys from "../util/LocalStorageKeys";
 import { safeGetIdentifier } from "../util/mobxutils";
 import {
-  ChoreolibEvent,
   Command,
   EventMarker,
   GroupCommand,
@@ -30,7 +29,6 @@ import {
 import {
   CommandStore,
   ICommandStore,
-  commandIsChoreolib,
   commandIsGroup,
   commandIsNamed,
   commandIsWait
@@ -93,13 +91,12 @@ export type EnvConstructors = {
         | {
             data: WaitCommand["data"] &
               GroupCommand["data"] &
-              NamedCommand["data"] &
-              ChoreolibEvent["data"];
+              NamedCommand["data"];
           }
         | object
       )
   ) => ICommandStore;
-  EventMarkerStore: (marker: EventMarker<Command>) => IEventMarkerStore;
+  EventMarkerStore: (marker: EventMarker) => IEventMarkerStore;
   ConstraintData: ConstraintDataConstructors;
   ConstraintStore: <K extends ConstraintKey>(
     type: K,
@@ -112,7 +109,7 @@ export type EnvConstructors = {
 function getConstructors(vars: () => IVariables): EnvConstructors {
   function createCommandStore(command: Command): ICommandStore {
     return CommandStore.create({
-      type: command.type,
+      type: command?.type ?? "none",
       name: commandIsNamed(command) ? command.data.name : "",
       commands: commandIsGroup(command)
         ? command.data.commands.map((c) => createCommandStore(c))
@@ -121,7 +118,6 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
         commandIsWait(command) ? command.data.waitTime : 0,
         "Time"
       ),
-      event: commandIsChoreolib(command) ? command.data.event : "",
       uuid: crypto.randomUUID()
     });
   }
@@ -182,14 +178,15 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
       return w;
     },
     CommandStore: createCommandStore,
-    EventMarkerStore: (marker: EventMarker<Command>): IEventMarkerStore => {
+    EventMarkerStore: (marker: EventMarker): IEventMarkerStore => {
       const m = EventMarkerStore.create({
-        data: {
+        name: marker.name,
+        from: {
           uuid: crypto.randomUUID(),
-          name: marker.data.name,
+
           target: undefined,
-          targetTimestamp: marker.data.targetTimestamp ?? undefined,
-          offset: vars().createExpression(marker.data.offset, "Time")
+          targetTimestamp: marker.from.targetTimestamp ?? undefined,
+          offset: vars().createExpression(marker.from.offset, "Time")
         },
         event: createCommandStore(marker.event),
         uuid: crypto.randomUUID()

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -170,7 +170,7 @@ export const DocumentStore = types
         });
 
       pathStore.markers.forEach((m) => {
-        m.data.setTrajectoryTargetIndex(m.data.getTargetIndex());
+        m.from.setTrajectoryTargetIndex(m.from.getTargetIndex());
       });
       pathStore.ui.setGenerating(true);
       const handle = pathStore.uuid
@@ -244,11 +244,11 @@ export const DocumentStore = types
               pathStore.trajectory.setSplits(result.trajectory.splits);
               pathStore.trajectory.setWaypoints(result.trajectory.waypoints);
               pathStore.markers.forEach((m) => {
-                const index = m.data.trajectoryTargetIndex;
+                const index = m.from.trajectoryTargetIndex;
                 if (index === undefined) {
-                  m.data.setTargetTimestamp(undefined);
+                  m.from.setTargetTimestamp(undefined);
                 } else {
-                  m.data.setTargetTimestamp(result.trajectory.waypoints[index]);
+                  m.from.setTargetTimestamp(result.trajectory.waypoints[index]);
                 }
               });
               pathStore.setSnapshot(result.snapshot);

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -44,6 +44,13 @@ export const SelectableItem = types.union(
   EventMarkerStore,
   ConstraintStore
 );
+function itemType(item: SelectableItemTypes) : "marker" | "constraint" | "waypoint" | undefined {
+  if (item === undefined) {return undefined;}
+  if (Object.hasOwn(item, "name")) {return "marker";}
+  if (Object.hasOwn(item, "from")) {return "constraint";}
+  if (Object.hasOwn(item, "fixTranslation")) {return "waypoint";}
+  return undefined;
+}
 export const ISampleType = types.enumeration<SampleType>([
   "Swerve",
   "Differential"
@@ -74,29 +81,23 @@ export const DocumentStore = types
         config: self.robotConfig.serialize
       };
     },
+    get isSidebarMarkerSelected() {
+      return itemType(self.selectedSidebarItem) === "marker";
+    },
     get isSidebarConstraintSelected() {
-      return (
-        self.selectedSidebarItem !== undefined &&
-        Object.hasOwn(self.selectedSidebarItem, "from")
-      );
+      return itemType(self.selectedSidebarItem) === "constraint";
     },
     get isSidebarWaypointSelected() {
-      return (
-        self.selectedSidebarItem !== undefined &&
-        !this.isSidebarConstraintSelected
-      );
+      return itemType(self.selectedSidebarItem) === "waypoint";
+    },
+    get isSidebarMarkerHovered() {
+      return itemType(self.hoveredSidebarItem) === "marker";
     },
     get isSidebarConstraintHovered() {
-      return (
-        self.hoveredSidebarItem !== undefined &&
-        Object.hasOwn(self.hoveredSidebarItem, "from")
-      );
+      return itemType(self.hoveredSidebarItem) === "constraint";
     },
     get isSidebarWaypointHovered() {
-      return (
-        self.hoveredSidebarItem !== undefined &&
-        !this.isSidebarConstraintHovered
-      );
+      return itemType(self.hoveredSidebarItem) === "waypoint";
     },
     get hoveredWaypointIndex() {
       if (this.isSidebarWaypointHovered) {

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -44,11 +44,21 @@ export const SelectableItem = types.union(
   EventMarkerStore,
   ConstraintStore
 );
-function itemType(item: SelectableItemTypes) : "marker" | "constraint" | "waypoint" | undefined {
-  if (item === undefined) {return undefined;}
-  if (Object.hasOwn(item, "name")) {return "marker";}
-  if (Object.hasOwn(item, "from")) {return "constraint";}
-  if (Object.hasOwn(item, "fixTranslation")) {return "waypoint";}
+function itemType(
+  item: SelectableItemTypes
+): "marker" | "constraint" | "waypoint" | undefined {
+  if (item === undefined) {
+    return undefined;
+  }
+  if (Object.hasOwn(item, "name")) {
+    return "marker";
+  }
+  if (Object.hasOwn(item, "from")) {
+    return "constraint";
+  }
+  if (Object.hasOwn(item, "fixTranslation")) {
+    return "waypoint";
+  }
   return undefined;
 }
 export const ISampleType = types.enumeration<SampleType>([

--- a/src/document/EventMarkerStore.tsx
+++ b/src/document/EventMarkerStore.tsx
@@ -1,6 +1,5 @@
 import { Instance, getEnv, getParent, isAlive, types } from "mobx-state-tree";
 import {
-  Command,
   EventMarker,
   EventMarkerData,
   WaypointUUID
@@ -20,7 +19,6 @@ import {
 
 export const EventMarkerDataStore = types
   .model("EventMarkerData", {
-    name: types.string,
     target: types.maybe(WaypointScope),
     targetTimestamp: types.maybe(types.number),
     offset: ExpressionStore,
@@ -61,7 +59,6 @@ export const EventMarkerDataStore = types
     get serialize(): EventMarkerData {
       const points = self.getPath().params.waypoints;
       return {
-        name: self.name,
         target: waypointIdToSavedWaypointId(self.target, points),
         offset: self.offset.serialize,
         targetTimestamp: self.targetTimestamp
@@ -71,16 +68,12 @@ export const EventMarkerDataStore = types
   .actions((self) => ({
     deserialize(ser: EventMarkerData) {
       const points = self.getPath().params.waypoints;
-      self.name = ser.name;
       self.target = savedWaypointIdToWaypointId(ser.target, points);
       self.targetTimestamp = self.targetTimestamp ?? undefined;
       self.offset.deserialize(ser.offset);
     },
     setTarget(target: WaypointUUID) {
       self.target = target;
-    },
-    setName(name: string) {
-      self.name = name;
     },
     setTargetTimestamp(timestamp: number | undefined) {
       self.targetTimestamp = timestamp;
@@ -123,14 +116,16 @@ export const EventMarkerDataStore = types
 
 export const EventMarkerStore = types
   .model("GeneralMarker", {
-    data: EventMarkerDataStore,
+    name: types.string,
+    from: EventMarkerDataStore,
     uuid: types.identifier,
     event: CommandStore
   })
   .views((self) => ({
-    get serialize(): EventMarker<Command> {
+    get serialize(): EventMarker {
       return {
-        data: self.data.serialize,
+        name: self.name,
+        from: self.from.serialize,
         event: self.event.serialize
       };
     },
@@ -142,8 +137,12 @@ export const EventMarkerStore = types
     }
   }))
   .actions((self) => ({
-    deserialize(ser: EventMarker<Command>) {
-      self.data.deserialize(ser.data);
+    setName(name: string) {
+      self.name = name;
+    },
+    deserialize(ser: EventMarker) {
+      self.name = ser.name;
+      self.from.deserialize(ser.from);
       self.event.deserialize(ser.event);
     },
     setSelected(selected: boolean) {


### PR DESCRIPTION
New Spec:
All markers in the `events` property of .traj root
```js
{
   name: "used for triggers",
   from: {
      offset: Expression
      targetTimestamp: number // offset.val + targetTimestamp = marker timestamp
      target: WaypointIDX // ignored by libraries
    },
    to: { // same as from, reserved for later},
    event: {/*pplib command with waitTime an Expression*/} | null //markers can have no gui-attached command.
}
```


