### PR TITLE
Re-enable opening of last project

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -282,8 +282,8 @@ export function setup() {
   doc.history.clear();
   setupEventListeners()
     .then(() => newProject())
-    .then(() => uiState.updateWindowTitle());
-  // .then(() => openProjectFile())
+    .then(() => uiState.updateWindowTitle())
+    .then(() => openProjectFile());
 }
 setup();
 


### PR DESCRIPTION
This was fully reimplemented, but disabled, probably as an artifact of a debugging session.