### PR TITLE
Fix incorrect title of example in choreolib autoroutine docs

### DIFF
--- a/docs/choreolib/auto-routines.md
+++ b/docs/choreolib/auto-routines.md
@@ -155,7 +155,7 @@ public AutoRoutine fivePieceAutoTriggerSeg(AutoFactory factory) {
 }
 ```
 
-## Creating an auto routine with composition and a monolithic trajectory
+## Creating an auto routine with triggers and a monolithic trajectory
 
 ```java
 public AutoRoutine fivePieceAutoTriggerMono(AutoFactory factory) {


### PR DESCRIPTION
The title for the second example listed here https://sleipnirgroup.github.io/Choreo/choreolib/auto-routines/ seems to be mistakenly 

> Creating an auto routine with **composition** and a monolithic trajectory 

which is the same title as the last, (don't do this), example. I believe this was instead meant to say

>  Creating an auto routine with **triggers** and a monolithic trajectory