### PR TITLE
Replace no-args trigger factories(done(), active(), running(), etc.) with public properties

### DIFF
--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -82,11 +82,6 @@ public class AutoFactory {
 
         @Override
         public void reset() {}
-
-        @Override
-        public Trigger running() {
-          return new Trigger(loop, () -> false);
-        }
       };
 
   /** A class used to bind commands to events in all trajectories created by this factory. */
@@ -327,7 +322,7 @@ public class AutoFactory {
    */
   public AutoRoutine commandAsAutoRoutine(Command cmd) {
     AutoRoutine routine = newRoutine(cmd.getName());
-    routine.running().onTrue(cmd);
+    routine.running.onTrue(cmd);
     return routine;
   }
 

--- a/choreolib/src/main/java/choreo/auto/AutoRoutine.java
+++ b/choreolib/src/main/java/choreo/auto/AutoRoutine.java
@@ -20,12 +20,12 @@ import java.util.function.BooleanSupplier;
  */
 public class AutoRoutine {
   /** The underlying {@link EventLoop} that triggers are bound to and polled */
-  protected final EventLoop loop;
+  protected EventLoop loop;
 
   /** The name of the auto routine this loop is associated with */
   protected final String name;
 
-  /** A boolean utilized in {@link #running()} to resolve trueness */
+  /** A boolean utilized in {@link #running} to resolve trueness */
   protected boolean isActive = false;
 
   /** A boolean that is true when the loop is killed */
@@ -43,6 +43,8 @@ public class AutoRoutine {
   public AutoRoutine(String name) {
     this.loop = new EventLoop();
     this.name = name;
+    // initialize triggers
+    this.running = new Trigger(loop, () -> isActive && DriverStation.isAutonomousEnabled());
   }
 
   /**
@@ -54,6 +56,8 @@ public class AutoRoutine {
   protected AutoRoutine(String name, EventLoop loop) {
     this.loop = loop;
     this.name = name;
+    // initialize triggers
+    this.running = new Trigger(loop, () -> isActive && DriverStation.isAutonomousEnabled());
   }
 
   /**
@@ -61,12 +65,8 @@ public class AutoRoutine {
    *
    * <p>Using a {@link Trigger#onFalse(Command)} will do nothing as when this is false the routine
    * is not being polled anymore.
-   *
-   * @return A {@link Trigger} that is true while this autonomous routine is being polled.
    */
-  public Trigger running() {
-    return new Trigger(loop, () -> isActive && DriverStation.isAutonomousEnabled());
-  }
+  public final Trigger running;
 
   /** Polls the routine. Should be called in the autonomous periodic method. */
   public void poll() {
@@ -144,4 +144,7 @@ public class AutoRoutine {
         .until(() -> !DriverStation.isAutonomousEnabled() || finishCondition.getAsBoolean())
         .withName(name);
   }
+
+  /** @deprecated Use the public property {@link #running} instead. */
+  @Deprecated(forRemoval = true) public Trigger running() { return this.running; }
 }

--- a/choreolib/src/test/java/choreo/auto/DoneTest.java
+++ b/choreolib/src/test/java/choreo/auto/DoneTest.java
@@ -35,7 +35,7 @@ public class DoneTest {
     AutoRoutine routine = factory.newRoutine("test");
     AutoTrajectory traj = factory.trajectory(trajectory, routine);
 
-    BooleanSupplier done = traj.done();
+    BooleanSupplier done = traj.done;
     BooleanSupplier doneDelayed = traj.done(2);
 
     SimHooks.pauseTiming();
@@ -52,7 +52,7 @@ public class DoneTest {
     scheduler.run();
 
     assertTrue(routine.isActive);
-    assertTrue(traj.active());
+    assertTrue(traj.active);
 
     SimHooks.stepTiming(1.0);
     scheduler.run();
@@ -60,7 +60,7 @@ public class DoneTest {
     scheduler.run();
     SimHooks.stepTiming(1.05);
     scheduler.run();
-    assertTrue(traj.inactive());
+    assertTrue(traj.inactive);
 
     assertTrue(done);
     assertTrue(done);


### PR DESCRIPTION
Resolves https://github.com/SleipnirGroup/Choreo/issues/897

Since these triggers are used so often, they can help significantly reduce clutter in the code.
Before:
```
path1.done().onTrue(...)
path2.active().onTrue(...)
```
Now:
```
path1.done.onTrue(...)
path2.active.onTrue(...)
```
This also reduces the number of allocations.