### PR TITLE
Added routine.trajectory() method

### DIFF
--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -33,9 +33,7 @@ import java.util.function.Supplier;
  */
 public class AutoFactory {
   static final AutoRoutine VOID_ROUTINE =
-      new AutoRoutine("VOID-ROUTINE") {
-        private final EventLoop loop = new EventLoop();
-
+      new AutoRoutine(null, "VOID-ROUTINE", new EventLoop()) {
         @Override
         public Command cmd() {
           return Commands.none().withName("VoidAutoRoutine");
@@ -177,7 +175,7 @@ public class AutoFactory {
       trajectoryCache.clear();
     }
 
-    return new AutoRoutine(name, this::allianceKnownOrIgnored);
+    return new AutoRoutine(this, name, this::allianceKnownOrIgnored);
   }
 
   private boolean allianceKnownOrIgnored() {
@@ -196,13 +194,11 @@ public class AutoFactory {
   }
 
   /**
-   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
-   *
-   * @param trajectoryName The name of the trajectory to use.
-   * @param routine The {@link AutoRoutine} to register this trajectory under.
-   * @return A new {@link AutoTrajectory}.
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
+   * 
+   * @see AutoRoutine#trajectory(String)
    */
-  public AutoTrajectory trajectory(String trajectoryName, AutoRoutine routine) {
+  AutoTrajectory trajectory(String trajectoryName, AutoRoutine routine) {
     Optional<? extends Trajectory<?>> optTrajectory =
         trajectoryCache.loadTrajectory(trajectoryName);
     Trajectory<?> trajectory;
@@ -216,15 +212,11 @@ public class AutoFactory {
   }
 
   /**
-   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
-   *
-   * @param trajectoryName The name of the trajectory to use.
-   * @param splitIndex The index of the split trajectory to use.
-   * @param routine The {@link AutoRoutine} to register this trajectory under.
-   * @return A new {@link AutoTrajectory}.
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
+   * 
+   * @see AutoRoutine#trajectory(String, int)
    */
-  public AutoTrajectory trajectory(
-      String trajectoryName, final int splitIndex, AutoRoutine routine) {
+  AutoTrajectory trajectory(String trajectoryName, final int splitIndex, AutoRoutine routine) {
     Optional<? extends Trajectory<?>> optTrajectory =
         trajectoryCache.loadTrajectory(trajectoryName, splitIndex);
     Trajectory<?> trajectory;
@@ -238,21 +230,17 @@ public class AutoFactory {
   }
 
   /**
-   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
-   *
-   * @param <SampleType> The type of the trajectory samples.
-   * @param trajectory The trajectory to use.
-   * @param routine The {@link AutoRoutine} to register this trajectory under.
-   * @return A new {@link AutoTrajectory}.
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
+   * 
+   * @see AutoRoutine#trajectory(Trajectory)
    */
   @SuppressWarnings("unchecked")
-  public <SampleType extends TrajectorySample<SampleType>> AutoTrajectory trajectory(
-      Trajectory<SampleType> trajectory, AutoRoutine routine) {
+  public <ST extends TrajectorySample<ST>> AutoTrajectory trajectory(Trajectory<ST> trajectory, AutoRoutine routine) {
     // type solidify everything
-    final Trajectory<SampleType> solidTrajectory = trajectory;
-    final Consumer<SampleType> solidController = (Consumer<SampleType>) this.controller;
-    final Optional<TrajectoryLogger<SampleType>> solidLogger =
-        this.trajectoryLogger.map(logger -> (TrajectoryLogger<SampleType>) logger);
+    final Trajectory<ST> solidTrajectory = trajectory;
+    final Consumer<ST> solidController = (Consumer<ST>) this.controller;
+    final Optional<TrajectoryLogger<ST>> solidLogger =
+        this.trajectoryLogger.map(logger -> (TrajectoryLogger<ST>) logger);
     return new AutoTrajectory(
         trajectory.name(),
         solidTrajectory,

--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -194,8 +194,9 @@ public class AutoFactory {
   }
 
   /**
-   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
-   * 
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link
+   * AutoRoutine}.
+   *
    * @see AutoRoutine#trajectory(String)
    */
   AutoTrajectory trajectory(String trajectoryName, AutoRoutine routine) {
@@ -212,8 +213,9 @@ public class AutoFactory {
   }
 
   /**
-   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
-   * 
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link
+   * AutoRoutine}.
+   *
    * @see AutoRoutine#trajectory(String, int)
    */
   AutoTrajectory trajectory(String trajectoryName, final int splitIndex, AutoRoutine routine) {
@@ -230,12 +232,14 @@ public class AutoFactory {
   }
 
   /**
-   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link AutoRoutine}.
-   * 
+   * A package protected method to create a new {@link AutoTrajectory} to be used in an {@link
+   * AutoRoutine}.
+   *
    * @see AutoRoutine#trajectory(Trajectory)
    */
   @SuppressWarnings("unchecked")
-  public <ST extends TrajectorySample<ST>> AutoTrajectory trajectory(Trajectory<ST> trajectory, AutoRoutine routine) {
+  public <ST extends TrajectorySample<ST>> AutoTrajectory trajectory(
+      Trajectory<ST> trajectory, AutoRoutine routine) {
     // type solidify everything
     final Trajectory<ST> solidTrajectory = trajectory;
     final Consumer<ST> solidController = (Consumer<ST>) this.controller;

--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -238,7 +238,7 @@ public class AutoFactory {
    * @see AutoRoutine#trajectory(Trajectory)
    */
   @SuppressWarnings("unchecked")
-  public <ST extends TrajectorySample<ST>> AutoTrajectory trajectory(
+  <ST extends TrajectorySample<ST>> AutoTrajectory trajectory(
       Trajectory<ST> trajectory, AutoRoutine routine) {
     // type solidify everything
     final Trajectory<ST> solidTrajectory = trajectory;

--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -167,7 +167,6 @@ public class AutoFactory {
    *
    * @param name The name of the {@link AutoRoutine}.
    * @return A new {@link AutoRoutine}.
-   * @see #voidRoutine
    */
   public AutoRoutine newRoutine(String name) {
     // Clear cache in simulation to allow a form of "hot-reloading" trajectories
@@ -180,17 +179,6 @@ public class AutoFactory {
 
   private boolean allianceKnownOrIgnored() {
     return !useAllianceFlipping.getAsBoolean() || alliance.get().isPresent();
-  }
-
-  /**
-   * An {@link AutoRoutine} that cannot have any side-effects, it stores no state and does nothing
-   * when polled.
-   *
-   * @return A void {@link AutoRoutine}.
-   * @see #newRoutine
-   */
-  public AutoRoutine voidRoutine() {
-    return VOID_ROUTINE;
   }
 
   /**

--- a/choreolib/src/main/java/choreo/auto/AutoRoutine.java
+++ b/choreolib/src/main/java/choreo/auto/AutoRoutine.java
@@ -10,6 +10,9 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.function.BooleanSupplier;
 
+import choreo.trajectory.Trajectory;
+import choreo.trajectory.TrajectorySample;
+
 /**
  * An object that represents an autonomous routine.
  *
@@ -19,6 +22,12 @@ import java.util.function.BooleanSupplier;
  * @see AutoFactory#newRoutine Creating a routine from a AutoFactory
  */
 public class AutoRoutine {
+  /**
+   * The factory that created this loop. This is used to create commands that are associated with
+   * this loop.
+   */
+  protected final AutoFactory factory;
+
   /** The underlying {@link EventLoop} that triggers are bound to and polled */
   protected final EventLoop loop;
 
@@ -38,14 +47,26 @@ public class AutoRoutine {
   protected BooleanSupplier allianceKnownOrIgnored = () -> true;
 
   /**
+   * A constructor to be used when inhereting this class to instantiate a custom inner loop
+   *
+   * @param name The name of the loop
+   * @param loop The inner {@link EventLoop}
+   */
+  protected AutoRoutine(AutoFactory factory, String name, EventLoop loop) {
+    this.factory = factory;
+    this.loop = loop;
+    this.name = name;
+  }
+
+  /**
    * Creates a new loop with a specific name
    *
+   * @param factory The factory that created this loop
    * @param name The name of the loop
    * @see AutoFactory#newRoutine Creating a loop from a AutoFactory
    */
-  public AutoRoutine(String name) {
-    this.loop = new EventLoop();
-    this.name = name;
+  protected AutoRoutine(AutoFactory factory, String name) {
+    this(factory, name, new EventLoop());
   }
 
   /**
@@ -56,21 +77,9 @@ public class AutoRoutine {
    *     flipping is not being done).
    * @see AutoFactory#newRoutine Creating a loop from a AutoFactory
    */
-  public AutoRoutine(String name, BooleanSupplier allianceKnownOrIgnored) {
-    this.loop = new EventLoop();
-    this.name = name;
+  protected AutoRoutine(AutoFactory factory, String name, BooleanSupplier allianceKnownOrIgnored) {
+    this(factory, name);
     this.allianceKnownOrIgnored = allianceKnownOrIgnored;
-  }
-
-  /**
-   * A constructor to be used when inhereting this class to instantiate a custom inner loop
-   *
-   * @param name The name of the loop
-   * @param loop The inner {@link EventLoop}
-   */
-  protected AutoRoutine(String name, EventLoop loop) {
-    this.loop = loop;
-    this.name = name;
   }
 
   /**
@@ -135,6 +144,38 @@ public class AutoRoutine {
     reset();
     DriverStation.reportWarning("Killed An Auto Loop", true);
     isKilled = true;
+  }
+
+  /**
+   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
+   *
+   * @param trajectoryName The name of the trajectory to use.
+   * @return A new {@link AutoTrajectory}.
+   */
+  public AutoTrajectory trajectory(String trajectoryName) {
+    return factory.trajectory(trajectoryName, this);
+  }
+
+  /**
+   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
+   *
+   * @param trajectoryName The name of the trajectory to use.
+   * @param splitIndex The index of the split trajectory to use.
+   * @return A new {@link AutoTrajectory}.
+   */
+  public AutoTrajectory trajectory(String trajectoryName, final int splitIndex) {
+    return factory.trajectory(trajectoryName, splitIndex, this);
+  }
+
+  /**
+   * Creates a new {@link AutoTrajectory} to be used in an auto routine.
+   *
+   * @param <SampleType> The type of the trajectory samples.
+   * @param trajectory The trajectory to use.
+   * @return A new {@link AutoTrajectory}.
+   */
+  public <SampleType extends TrajectorySample<SampleType>> AutoTrajectory trajectory(Trajectory<SampleType> trajectory) {
+    return factory.trajectory(trajectory, this);
   }
 
   /**

--- a/choreolib/src/main/java/choreo/auto/AutoRoutine.java
+++ b/choreolib/src/main/java/choreo/auto/AutoRoutine.java
@@ -2,6 +2,8 @@
 
 package choreo.auto;
 
+import choreo.trajectory.Trajectory;
+import choreo.trajectory.TrajectorySample;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.event.EventLoop;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -9,9 +11,6 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.function.BooleanSupplier;
-
-import choreo.trajectory.Trajectory;
-import choreo.trajectory.TrajectorySample;
 
 /**
  * An object that represents an autonomous routine.
@@ -174,7 +173,8 @@ public class AutoRoutine {
    * @param trajectory The trajectory to use.
    * @return A new {@link AutoTrajectory}.
    */
-  public <SampleType extends TrajectorySample<SampleType>> AutoTrajectory trajectory(Trajectory<SampleType> trajectory) {
+  public <SampleType extends TrajectorySample<SampleType>> AutoTrajectory trajectory(
+      Trajectory<SampleType> trajectory) {
     return factory.trajectory(trajectory, this);
   }
 

--- a/choreolib/src/main/java/choreo/auto/AutoRoutine.java
+++ b/choreolib/src/main/java/choreo/auto/AutoRoutine.java
@@ -48,6 +48,7 @@ public class AutoRoutine {
   /**
    * A constructor to be used when inhereting this class to instantiate a custom inner loop
    *
+   * @param factory The factory that created this loop
    * @param name The name of the loop
    * @param loop The inner {@link EventLoop}
    */
@@ -71,6 +72,7 @@ public class AutoRoutine {
   /**
    * Creates a new loop with a specific name and a custom alliance supplier.
    *
+   * @param factory The factory that created this loop
    * @param name The name of the loop
    * @param allianceKnownOrIgnored Returns true if the alliance is known or is irrelevant (i.e.
    *     flipping is not being done).

--- a/docs/choreolib/auto-factory.md
+++ b/docs/choreolib/auto-factory.md
@@ -67,7 +67,7 @@ public Robot extends TimedRobot {
   private AutoRoutine twoPieceAuto(AutoFactory factory) {
     final AutoRoutine routine = factory.newRoutine("twoPieceAuto");
 
-    final AutoTrajectory trajectory = factory.trajectory("twoPieceAuto", routine);
+    final AutoTrajectory trajectory = routine.trajectory("twoPieceAuto");
 
     routine.running()
         .onTrue(

--- a/docs/choreolib/auto-routines.md
+++ b/docs/choreolib/auto-routines.md
@@ -82,13 +82,13 @@ public AutoRoutine fivePieceAutoTriggerSeg(AutoFactory factory) {
   // AMP, SUB, SRC: The 3 starting positions
 
   // Try to load all the trajectories we need
-  final AutoTrajectory ampToC1 = routine.trajectory("ampToC1", routine);
-  final AutoTrajectory c1ToM1 = routine.trajectory("c1ToM1", routine);
-  final AutoTrajectory m1ToS1 = routine.trajectory("m1ToS1", routine);
-  final AutoTrajectory m1ToM2 = routine.trajectory("m1ToM2", routine);
-  final AutoTrajectory m2ToS1 = routine.trajectory("m2ToS2", routine);
-  final AutoTrajectory s1ToC2 = routine.trajectory("s1ToC2", routine);
-  final AutoTrajectory c2ToC3 = routine.trajectory("c2ToC3", routine);
+  final AutoTrajectory ampToC1 = routine.trajectory("ampToC1");
+  final AutoTrajectory c1ToM1 = routine.trajectory("c1ToM1");
+  final AutoTrajectory m1ToS1 = routine.trajectory("m1ToS1");
+  final AutoTrajectory m1ToM2 = routine.trajectory("m1ToM2");
+  final AutoTrajectory m2ToS1 = routine.trajectory("m2ToS2");
+  final AutoTrajectory s1ToC2 = routine.trajectory("s1ToC2");
+  final AutoTrajectory c2ToC3 = routine.trajectory("c2ToC3");
 
   // entry point for the auto
   // resets the odometry to the starting position,
@@ -168,7 +168,7 @@ public AutoRoutine fivePieceAutoTriggerSeg(AutoFactory factory) {
 public Command fivePieceAutoTriggerMono(AutoFactory factory) {
   final AutoRoutine routine = factory.newRoutine("fivePieceAuto");
   final Alert noStartingPoseErr = new Alert("Error: 5 piece auto has no starting pose", AlertType.kError);
-  final AutoTrajectory trajectory = routine.trajectory("fivePieceAuto", routine);
+  final AutoTrajectory trajectory = routine.trajectory("fivePieceAuto");
 
   // entry point for the auto
   // resets the odometry to the starting position,

--- a/docs/choreolib/auto-routines.md
+++ b/docs/choreolib/auto-routines.md
@@ -82,13 +82,13 @@ public AutoRoutine fivePieceAutoTriggerSeg(AutoFactory factory) {
   // AMP, SUB, SRC: The 3 starting positions
 
   // Try to load all the trajectories we need
-  final AutoTrajectory ampToC1 = factory.trajectory("ampToC1", routine);
-  final AutoTrajectory c1ToM1 = factory.trajectory("c1ToM1", routine);
-  final AutoTrajectory m1ToS1 = factory.trajectory("m1ToS1", routine);
-  final AutoTrajectory m1ToM2 = factory.trajectory("m1ToM2", routine);
-  final AutoTrajectory m2ToS1 = factory.trajectory("m2ToS2", routine);
-  final AutoTrajectory s1ToC2 = factory.trajectory("s1ToC2", routine);
-  final AutoTrajectory c2ToC3 = factory.trajectory("c2ToC3", routine);
+  final AutoTrajectory ampToC1 = routine.trajectory("ampToC1", routine);
+  final AutoTrajectory c1ToM1 = routine.trajectory("c1ToM1", routine);
+  final AutoTrajectory m1ToS1 = routine.trajectory("m1ToS1", routine);
+  final AutoTrajectory m1ToM2 = routine.trajectory("m1ToM2", routine);
+  final AutoTrajectory m2ToS1 = routine.trajectory("m2ToS2", routine);
+  final AutoTrajectory s1ToC2 = routine.trajectory("s1ToC2", routine);
+  final AutoTrajectory c2ToC3 = routine.trajectory("c2ToC3", routine);
 
   // entry point for the auto
   // resets the odometry to the starting position,
@@ -168,7 +168,7 @@ public AutoRoutine fivePieceAutoTriggerSeg(AutoFactory factory) {
 public Command fivePieceAutoTriggerMono(AutoFactory factory) {
   final AutoRoutine routine = factory.newRoutine("fivePieceAuto");
   final Alert noStartingPoseErr = new Alert("Error: 5 piece auto has no starting pose", AlertType.kError);
-  final AutoTrajectory trajectory = factory.trajectory("fivePieceAuto", routine);
+  final AutoTrajectory trajectory = routine.trajectory("fivePieceAuto", routine);
 
   // entry point for the auto
   // resets the odometry to the starting position,
@@ -213,7 +213,7 @@ public AutoRoutine fivePieceAutoCompositionSeg(AutoFactory factory) {
   // value
   // AMP, SUB, SRC: The 3 starting positions
   // Try to load all the trajectories we need
-  final AutoTrajectory ampToC1 = factory.trajectory("ampToC1", factory.voidLoop());
+  final AutoTrajectory ampToC1 = routine.trajectory("ampToC1", factory.voidRoutine());
   final Command c1ToM1 = factory.trajectoryCommand("c1ToM1");
   final Command m1ToS1 = factory.trajectoryCommand("m1ToS1");
   final Command m1ToM2 = factory.trajectoryCommand("m1ToM2");

--- a/docs/choreolib/auto-routines.md
+++ b/docs/choreolib/auto-routines.md
@@ -213,7 +213,7 @@ public AutoRoutine fivePieceAutoCompositionSeg(AutoFactory factory) {
   // value
   // AMP, SUB, SRC: The 3 starting positions
   // Try to load all the trajectories we need
-  final AutoTrajectory ampToC1 = routine.trajectory("ampToC1", factory.voidRoutine());
+  final AutoTrajectory ampToC1 = factory.voidRoutine().trajectory("ampToC1");
   final Command c1ToM1 = factory.trajectoryCommand("c1ToM1");
   final Command m1ToS1 = factory.trajectoryCommand("m1ToS1");
   final Command m1ToM2 = factory.trajectoryCommand("m1ToM2");


### PR DESCRIPTION
Currently, the way to construct AutoTrajectories is using the factory.trajectory method:
```
var trajectory = factory.trajectory("AmpToC1", routine);
```

This PR provides a better-named alternative:
```
var trajectory = routine.trajectory("AmpToC1");
```

Note: c++ and docs updates are still tbd.