### PR TITLE
Chor autosave now triggers on serialized version, not undo stack size

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -405,7 +405,7 @@ export async function setupEventListeners() {
       });
     });
   const autoSaveUnlisten = reaction(
-    () => doc.history.undoIdx,
+    () => doc.serializeChor(),
     () => {
       if (uiState.hasSaveLocation) {
         saveProject();


### PR DESCRIPTION
This matches the mechanism used for .traj files.