### PR TITLE
Fix docs logo

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
-  icon: media/icon1024x1024.png
+  logo: media/icon1024x1024.png
   favicon: media/icon1024x1024.png
   features:
     - content.code.copy


### PR DESCRIPTION
The docs have had the default mkdocs-material logo for a while. It looks like somebody tried to configure it to put the choreo logo in, but used the wrong config key. This adds the logo to the header.