### PR TITLE
Add a newline to the end of .traj and .chor writing

### DIFF
--- a/src-core/src/file_management/mod.rs
+++ b/src-core/src/file_management/mod.rs
@@ -37,6 +37,8 @@ async fn write_serializable<T: Serialize + Send>(contents: T, file: &Path) -> Ch
         .ok_or_else(|| ChoreoError::FileWrite(file.to_path_buf()))?;
     fs::create_dir_all(parent).await?;
     fs::write(file, json).await?;
+    // end with a blank line to make e.g. wpiformat happy
+    fs::write(file, "\n").await?;
     Ok(())
 }
 


### PR DESCRIPTION
This is primarily for formatters like wpiformat to pass the file.