### PR TITLE
Improve atPose clarity, routine-active safety, alliance-flipping safety

### DIFF
--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -460,22 +460,27 @@ public class AutoTrajectory {
     return trig;
   }
 
-  private Trigger atPose(Supplier<Optional<Pose2d>> pose, double toleranceMeters, double toleranceRadians) {
+  private Trigger atPose(
+      Supplier<Optional<Pose2d>> pose, double toleranceMeters, double toleranceRadians) {
     return new Trigger(
-      routine.loop(),
-      () -> {
-        Optional<Pose2d> checkedPoseOpt = pose.get();
-        return checkedPoseOpt
-            .map(
-                (checkedPose) -> {
-                  Translation2d currentTrans = poseSupplier.get().getTranslation();
-                  Rotation2d currentRot = poseSupplier.get().getRotation();
-                  return currentTrans.getDistance(checkedPose.getTranslation()) < toleranceMeters
-                    && Math.abs(currentRot.minus(checkedPose.getRotation()).getRadians()) < toleranceRadians;
-                })
-            .orElse(false);
-      });
+            routine.loop(),
+            () -> {
+              Optional<Pose2d> checkedPoseOpt = pose.get();
+              return checkedPoseOpt
+                  .map(
+                      (checkedPose) -> {
+                        Translation2d currentTrans = poseSupplier.get().getTranslation();
+                        Rotation2d currentRot = poseSupplier.get().getRotation();
+                        return currentTrans.getDistance(checkedPose.getTranslation())
+                                < toleranceMeters
+                            && Math.abs(currentRot.minus(checkedPose.getRotation()).getRadians())
+                                < toleranceRadians;
+                      })
+                  .orElse(false);
+            })
+        .and(active());
   }
+
   /**
    * Returns a trigger that is true when the robot is within toleranceMeters of the given pose.
    *
@@ -490,8 +495,10 @@ public class AutoTrajectory {
    * @return A trigger that is true when the robot is within toleranceMeters of the given pose.
    */
   public Trigger atPose(Optional<Pose2d> pose, double toleranceMeters, double toleranceRadians) {
-    return atPose(AllianceFlipUtil.optionalFlippedPose2d(pose, alliance, useAllianceFlipping),
-      toleranceMeters, toleranceRadians);
+    return atPose(
+        AllianceFlipUtil.optionalFlippedPose2d(pose, alliance, useAllianceFlipping),
+        toleranceMeters,
+        toleranceRadians);
   }
 
   /**
@@ -512,8 +519,8 @@ public class AutoTrajectory {
   }
 
   /**
-   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of the given event's
-   * pose.
+   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of
+   * the given event's pose.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
@@ -541,7 +548,8 @@ public class AutoTrajectory {
               // this also lets atPose be called before the alliance is ready
               .sampleAt(event.timestamp, false)
               .map(TrajectorySample::getPose);
-      if (poseOpt.isPresent()) { // atPose accepts empty optionals but it would just be a false trigger
+      if (poseOpt
+          .isPresent()) { // atPose accepts empty optionals but it would just be a false trigger
         trig = trig.or(atPose(poseOpt, toleranceMeters, toleranceRadians));
         foundEvent = true;
       }
@@ -558,13 +566,15 @@ public class AutoTrajectory {
   }
 
   /**
-   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given event's pose. 
+   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given
+   * event's pose.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
-   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given event's pose.
+   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given
+   *     event's pose.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */
@@ -572,62 +582,72 @@ public class AutoTrajectory {
     return atPose(eventName, DEFAULT_TOLERANCE_METERS, DEFAULT_TOLERANCE_RADIANS);
   }
 
-  private Trigger atTranslation(Supplier<Optional<Translation2d>> translation, double toleranceMeters) {
+  private Trigger atTranslation(
+      Supplier<Optional<Translation2d>> translation, double toleranceMeters) {
     return new Trigger(
-      routine.loop(),
-      () -> {
-        Optional<Translation2d> checkedTranslationOpt = translation.get();
-        return checkedTranslationOpt
-            .map(
-                (checkedTranslation) -> {
-                  Translation2d currentTrans = poseSupplier.get().getTranslation();
-                  return currentTrans.getDistance(checkedTranslation) < toleranceMeters;
-                })
-            .orElse(false);
-      });
-  }
-  /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given translation.
-   *
-   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns Red.
-   *
-   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
-   * return false.
-   *
-   * @param translation The translation to check against, unflipped.
-   * @param toleranceMeters The tolerance in meters.
-   * @return A trigger that is true when the robot is within toleranceMeters of the given translation.
-   */
-  public Trigger atTranslation(Optional<Translation2d> translation, double toleranceMeters) {
-    return atTranslation(AllianceFlipUtil.optionalFlippedTranslation2d(translation, alliance, useAllianceFlipping), toleranceMeters);
+            routine.loop(),
+            () -> {
+              Optional<Translation2d> checkedTranslationOpt = translation.get();
+              return checkedTranslationOpt
+                  .map(
+                      (checkedTranslation) -> {
+                        Translation2d currentTrans = poseSupplier.get().getTranslation();
+                        return currentTrans.getDistance(checkedTranslation) < toleranceMeters;
+                      })
+                  .orElse(false);
+            })
+        .and(active());
   }
 
   /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given translation.
+   * Returns a trigger that is true when the robot is within toleranceMeters of the given
+   * translation.
    *
-   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns Red.
+   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns
+   * Red.
    *
    * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
    * return false.
    *
    * @param translation The translation to check against, unflipped.
    * @param toleranceMeters The tolerance in meters.
-   * @return A trigger that is true when the robot is within toleranceMeters of the given translation.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given
+   *     translation.
+   */
+  public Trigger atTranslation(Optional<Translation2d> translation, double toleranceMeters) {
+    return atTranslation(
+        AllianceFlipUtil.optionalFlippedTranslation2d(translation, alliance, useAllianceFlipping),
+        toleranceMeters);
+  }
+
+  /**
+   * Returns a trigger that is true when the robot is within toleranceMeters of the given
+   * translation.
+   *
+   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns
+   * Red.
+   *
+   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
+   * return false.
+   *
+   * @param translation The translation to check against, unflipped.
+   * @param toleranceMeters The tolerance in meters.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given
+   *     translation.
    */
   public Trigger atTranslation(Translation2d translation, double toleranceMeters) {
     return atTranslation(Optional.of(translation), toleranceMeters);
   }
 
   /**
-   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of the given event's
-   * translation.
+   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of
+   * the given event's translation.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
    * @param toleranceMeters The tolerance in meters.
-   * @param toleranceRadians The heading tolerance in radians.
    * @return A trigger that is true when the robot is within toleranceMeters of the given events
    *     translation.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
@@ -647,8 +667,11 @@ public class AutoTrajectory {
               // don't mirror here because the translations are mirrored themselves
               // this also lets atTranslation be called before the alliance is ready
               .sampleAt(event.timestamp, false)
-              .map(TrajectorySample::getPose).map(Pose2d::getTranslation);
-      if (translationOpt.isPresent()) { // atTranslation accepts empty optionals but it would just be a false trigger
+              .map(TrajectorySample::getPose)
+              .map(Pose2d::getTranslation);
+      if (translationOpt
+          .isPresent()) { // atTranslation accepts empty optionals but it would just be a false
+        // trigger
         trig = trig.or(atTranslation(translationOpt, toleranceMeters));
         foundEvent = true;
       }
@@ -665,13 +688,15 @@ public class AutoTrajectory {
   }
 
   /**
-   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given event's translation. 
+   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given
+   * event's translation.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
-   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given event's translation.
+   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given
+   *     event's translation.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -481,20 +481,7 @@ public class AutoTrajectory {
         .and(active());
   }
 
-  /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given pose.
-   *
-   * <p>The pose is flipped if alliance flipping is enabled and the alliance supplier returns Red.
-   *
-   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
-   * return false.
-   *
-   * @param pose The pose to check against, unflipped.
-   * @param toleranceMeters The tolerance in meters.
-   * @param toleranceRadians The heading tolerance in radians.
-   * @return A trigger that is true when the robot is within toleranceMeters of the given pose.
-   */
-  public Trigger atPose(Optional<Pose2d> pose, double toleranceMeters, double toleranceRadians) {
+  private Trigger atPose(Optional<Pose2d> pose, double toleranceMeters, double toleranceRadians) {
     return atPose(
         AllianceFlipUtil.optionalFlippedPose2d(pose, alliance, useAllianceFlipping),
         toleranceMeters,
@@ -599,22 +586,7 @@ public class AutoTrajectory {
         .and(active());
   }
 
-  /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given
-   * translation.
-   *
-   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns
-   * Red.
-   *
-   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
-   * return false.
-   *
-   * @param translation The translation to check against, unflipped.
-   * @param toleranceMeters The tolerance in meters.
-   * @return A trigger that is true when the robot is within toleranceMeters of the given
-   *     translation.
-   */
-  public Trigger atTranslation(Optional<Translation2d> translation, double toleranceMeters) {
+  private Trigger atTranslation(Optional<Translation2d> translation, double toleranceMeters) {
     return atTranslation(
         AllianceFlipUtil.optionalFlippedTranslation2d(translation, alliance, useAllianceFlipping),
         toleranceMeters);

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -11,6 +11,7 @@ import choreo.trajectory.Trajectory;
 import choreo.trajectory.TrajectorySample;
 import choreo.util.AllianceFlipUtil;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -39,7 +40,7 @@ public class AutoTrajectory {
   // and far between. This helps with more novice users
 
   private static final double DEFAULT_TOLERANCE_METERS = Units.inchesToMeters(3);
-
+  private static final double DEFAULT_TOLERANCE_RADIANS = Units.degreesToRadians(3);
   private final String name;
   private final Trajectory<? extends TrajectorySample<?>> trajectory;
   private final TrajectoryLogger<? extends TrajectorySample<?>> trajectoryLogger;
@@ -241,23 +242,6 @@ public class AutoTrajectory {
   }
 
   /**
-   * Will get the starting pose of the trajectory as a Supplier
-   *
-   * <p>This position is flipped when alliance flipping is enabled and the alliance supplier returns
-   * Red.
-   *
-   * <p>This Supplier returns an empty Optional if the trajectory is empty. This method returns an
-   * empty Optional if alliance flipping is enabled and the alliance supplier returns an empty
-   * Optional.
-   *
-   * @return The starting pose as a Supplier that will flip
-   */
-  public Supplier<Optional<Pose2d>> getInitialPoseSupplier() {
-    return AllianceFlipUtil.optionalFlipped(
-        trajectory.getInitialPose(false), alliance, useAllianceFlipping);
-  }
-
-  /**
    * Will get the ending pose of the trajectory.
    *
    * <p>This position is flipped if alliance flipping is enabled and the alliance supplier returns
@@ -274,23 +258,6 @@ public class AutoTrajectory {
       return Optional.empty();
     }
     return trajectory.getFinalPose(doFlip());
-  }
-
-  /**
-   * Will get the ending pose of the trajectory as a Supplier
-   *
-   * <p>This position is flipped when alliance flipping is enabled and the alliance supplier returns
-   * Red.
-   *
-   * <p>This Supplier returns an empty Optional if the trajectory is empty. This method returns an
-   * empty Optional if alliance flipping is enabled and the alliance supplier returns an empty
-   * Optional.
-   *
-   * @return The ending pose as a Supplier that will flip
-   */
-  public Supplier<Optional<Pose2d>> getFinalPoseSupplier() {
-    return AllianceFlipUtil.optionalFlipped(
-        trajectory.getFinalPose(false), alliance, useAllianceFlipping);
   }
 
   /**
@@ -415,6 +382,10 @@ public class AutoTrajectory {
     return done(0);
   }
 
+  private Supplier<Optional<Pose2d>> optionalFlipped(Optional<Pose2d> pose) {
+    return AllianceFlipUtil.optionalFlippedPose2d(pose, alliance, useAllianceFlipping);
+  }
+
   /**
    * Returns a trigger that will go true for 1 cycle when the desired time has elapsed
    *
@@ -489,32 +460,38 @@ public class AutoTrajectory {
     return trig;
   }
 
-  /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given pose.
-   *
-   * <p>The pose is flipped if alliance flipping is enabled and the alliance supplier returns Red.
-   *
-   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
-   * return false.
-   *
-   * @param pose The pose to check against, unflipped.
-   * @param toleranceMeters The tolerance in meters.
-   * @return A trigger that is true when the robot is within toleranceMeters of the given pose.
-   */
-  public Trigger atPose(Optional<Pose2d> pose, double toleranceMeters) {
-    Supplier<Optional<Pose2d>> checkedPoseOptSup = optionalFlipped(pose);
+  private Trigger atPose(Supplier<Optional<Pose2d>> pose, double toleranceMeters, double toleranceRadians) {
     return new Trigger(
-        routine.loop(),
-        () -> {
-          Optional<Pose2d> checkedPoseOpt = checkedPoseOptSup.get();
-          return checkedPoseOpt
-              .map(
-                  (checkedPose) -> {
-                    Translation2d currentTrans = poseSupplier.get().getTranslation();
-                    return currentTrans.getDistance(checkedPose.getTranslation()) < toleranceMeters;
-                  })
-              .orElse(false);
-        });
+      routine.loop(),
+      () -> {
+        Optional<Pose2d> checkedPoseOpt = pose.get();
+        return checkedPoseOpt
+            .map(
+                (checkedPose) -> {
+                  Translation2d currentTrans = poseSupplier.get().getTranslation();
+                  Rotation2d currentRot = poseSupplier.get().getRotation();
+                  return currentTrans.getDistance(checkedPose.getTranslation()) < toleranceMeters
+                    && Math.abs(currentRot.minus(checkedPose.getRotation()).getRadians()) < toleranceRadians;
+                })
+            .orElse(false);
+      });
+  }
+  /**
+   * Returns a trigger that is true when the robot is within toleranceMeters of the given pose.
+   *
+   * <p>The pose is flipped if alliance flipping is enabled and the alliance supplier returns Red.
+   *
+   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
+   * return false.
+   *
+   * @param pose The pose to check against, unflipped.
+   * @param toleranceMeters The tolerance in meters.
+   * @param toleranceRadians The heading tolerance in radians.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given pose.
+   */
+  public Trigger atPose(Optional<Pose2d> pose, double toleranceMeters, double toleranceRadians) {
+    return atPose(AllianceFlipUtil.optionalFlippedPose2d(pose, alliance, useAllianceFlipping),
+      toleranceMeters, toleranceRadians);
   }
 
   /**
@@ -527,18 +504,15 @@ public class AutoTrajectory {
    *
    * @param pose The pose to check against, unflipped.
    * @param toleranceMeters The tolerance in meters.
+   * @param toleranceRadians The heading tolerance in radians.
    * @return A trigger that is true when the robot is within toleranceMeters of the given pose.
    */
-  public Trigger atPose(Pose2d pose, double toleranceMeters) {
-    return atPose(Optional.of(pose), toleranceMeters);
-  }
-
-  private Supplier<Optional<Pose2d>> optionalFlipped(Optional<Pose2d> pose) {
-    return AllianceFlipUtil.optionalFlipped(pose, alliance, useAllianceFlipping);
+  public Trigger atPose(Pose2d pose, double toleranceMeters, double toleranceRadians) {
+    return atPose(Optional.of(pose), toleranceMeters, toleranceRadians);
   }
 
   /**
-   * Returns a trigger that is true when the robot is within toleranceMeters of the given events
+   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of the given event's
    * pose.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
@@ -546,12 +520,13 @@ public class AutoTrajectory {
    *
    * @param eventName The name of the event.
    * @param toleranceMeters The tolerance in meters.
+   * @param toleranceRadians The heading tolerance in radians.
    * @return A trigger that is true when the robot is within toleranceMeters of the given events
    *     pose.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */
-  public Trigger atPose(String eventName, double toleranceMeters) {
+  public Trigger atPose(String eventName, double toleranceMeters, double toleranceRadians) {
     boolean foundEvent = false;
     Trigger trig = offTrigger;
 
@@ -566,8 +541,8 @@ public class AutoTrajectory {
               // this also lets atPose be called before the alliance is ready
               .sampleAt(event.timestamp, false)
               .map(TrajectorySample::getPose);
-      if (poseOpt.isPresent()) {
-        trig = trig.or(atPose(poseOpt, toleranceMeters));
+      if (poseOpt.isPresent()) { // atPose accepts empty optionals but it would just be a false trigger
+        trig = trig.or(atPose(poseOpt, toleranceMeters, toleranceRadians));
         foundEvent = true;
       }
     }
@@ -583,53 +558,125 @@ public class AutoTrajectory {
   }
 
   /**
-   * Returns a trigger that is true when the robot is within 3 inches of the given events pose.
+   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given event's pose. 
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
-   * @return A trigger that is true when the robot is within 3 inches of the given events pose.
+   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given event's pose.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */
   public Trigger atPose(String eventName) {
-    return atPose(eventName, DEFAULT_TOLERANCE_METERS);
+    return atPose(eventName, DEFAULT_TOLERANCE_METERS, DEFAULT_TOLERANCE_RADIANS);
+  }
+
+  private Trigger atTranslation(Supplier<Optional<Translation2d>> translation, double toleranceMeters) {
+    return new Trigger(
+      routine.loop(),
+      () -> {
+        Optional<Translation2d> checkedTranslationOpt = translation.get();
+        return checkedTranslationOpt
+            .map(
+                (checkedTranslation) -> {
+                  Translation2d currentTrans = poseSupplier.get().getTranslation();
+                  return currentTrans.getDistance(checkedTranslation) < toleranceMeters;
+                })
+            .orElse(false);
+      });
+  }
+  /**
+   * Returns a trigger that is true when the robot is within toleranceMeters of the given translation.
+   *
+   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns Red.
+   *
+   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
+   * return false.
+   *
+   * @param translation The translation to check against, unflipped.
+   * @param toleranceMeters The tolerance in meters.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given translation.
+   */
+  public Trigger atTranslation(Optional<Translation2d> translation, double toleranceMeters) {
+    return atTranslation(AllianceFlipUtil.optionalFlippedTranslation2d(translation, alliance, useAllianceFlipping), toleranceMeters);
   }
 
   /**
-   * Returns a trigger that is true when the event with the given name has been reached based on
-   * time and the robot is within toleranceMeters of the given events pose.
+   * Returns a trigger that is true when the robot is within toleranceMeters of the given translation.
+   *
+   * <p>The translation is flipped if alliance flipping is enabled and the alliance supplier returns Red.
+   *
+   * <p>While alliance flipping is enabled and the alliance supplier returns empty, the trigger will
+   * return false.
+   *
+   * @param translation The translation to check against, unflipped.
+   * @param toleranceMeters The tolerance in meters.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given translation.
+   */
+  public Trigger atTranslation(Translation2d translation, double toleranceMeters) {
+    return atTranslation(Optional.of(translation), toleranceMeters);
+  }
+
+  /**
+   * Returns a trigger that is true when the robot is within toleranceMeters and toleranceRadians of the given event's
+   * translation.
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
    * @param toleranceMeters The tolerance in meters.
-   * @return A trigger that is true when the event with the given name has been reached based on
-   *     time and the robot is within toleranceMeters of the given events pose.
+   * @param toleranceRadians The heading tolerance in radians.
+   * @return A trigger that is true when the robot is within toleranceMeters of the given events
+   *     translation.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */
-  public Trigger atTimeAndPose(String eventName, double toleranceMeters) {
-    return atTime(eventName).and(atPose(eventName, toleranceMeters));
+  public Trigger atTranslation(String eventName, double toleranceMeters) {
+    boolean foundEvent = false;
+    Trigger trig = offTrigger;
+
+    for (var event : trajectory.getEvents(eventName)) {
+      // This could create a lot of objects, could be done a more efficient way
+      // with having it all be 1 trigger that just has a list of possess and checks each one each
+      // cycle or something like that.
+      // If choreo starts showing memory issues we can look into this.
+      Optional<Translation2d> translationOpt =
+          trajectory
+              // don't mirror here because the translations are mirrored themselves
+              // this also lets atTranslation be called before the alliance is ready
+              .sampleAt(event.timestamp, false)
+              .map(TrajectorySample::getPose).map(Pose2d::getTranslation);
+      if (translationOpt.isPresent()) { // atTranslation accepts empty optionals but it would just be a false trigger
+        trig = trig.or(atTranslation(translationOpt, toleranceMeters));
+        foundEvent = true;
+      }
+    }
+
+    // The user probably expects an event to exist if they're trying to do something at that event,
+    // report the missing event.
+    if (!foundEvent) {
+      DriverStation.reportWarning(
+          "[Choreo] Event \"" + eventName + "\" not found for " + name, true);
+    }
+
+    return trig;
   }
 
   /**
-   * Returns a trigger that is true when the event with the given name has been reached based on
-   * time and the robot is within 3 inches of the given events pose.
+   * Returns a trigger that is true when the robot is within 3 inches and 3 degrees of the given event's translation. 
    *
    * <p>A warning will be printed to the DriverStation if the event is not found and the trigger
    * will always be false.
    *
    * @param eventName The name of the event.
-   * @return A trigger that is true when the event with the given name has been reached based on
-   *     time and the robot is within 3 inches of the given events pose.
+   * @return A trigger that is true when the robot is within 3 inches and 3 degrees of the given event's translation.
    * @see <a href="https://choreo.autos/usage/editing-paths/#event-markers">Event Markers in the
    *     GUI</a>
    */
-  public Trigger atTimeAndPose(String eventName) {
-    return atTimeAndPose(eventName, DEFAULT_TOLERANCE_METERS);
+  public Trigger atTranslation(String eventName) {
+    return atTranslation(eventName, DEFAULT_TOLERANCE_METERS);
   }
 
   /**

--- a/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
+++ b/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
@@ -251,21 +251,7 @@ public class AllianceFlipUtil {
   }
 
   /**
-   * Creates a Supplier&lt;Optional&lt;Pose2d&gt;&gt; based on a
-   * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Pose2d&gt;
-   *
-   * @param pose The pose to flip
-   * @param alliance The current alliance
-   * @return empty if the alliance is empty; the original pose if the alliance is blue; the flipped
-   *     pose if the alliance is red
-   */
-  public static Supplier<Optional<Pose2d>> optionalFlippedPose2d(
-      Optional<Pose2d> pose, Supplier<Optional<Alliance>> alliance) {
-    return optionalFlippedPose2d(pose, alliance, () -> true);
-  }
-
-  /**
-   * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; based on a
+   * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; that is flipped based on a
    * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Translation2d&gt;
    *
    * @param translationOpt The translation to flip
@@ -288,19 +274,5 @@ public class AllianceFlipUtil {
                         translationOpt.map(
                             translation -> ally == Alliance.Red ? flip(translation) : translation))
             : translationOpt;
-  }
-
-  /**
-   * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; based on a
-   * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Translation2d&gt;
-   *
-   * @param translation The translation to flip
-   * @param alliance The current alliance
-   * @return empty if the alliance is empty; the original translation if the alliance is blue; the
-   *     flipped translation if the alliance is red
-   */
-  public static Supplier<Optional<Translation2d>> optionalFlippedTranslation2d(
-      Optional<Translation2d> translation, Supplier<Optional<Alliance>> alliance) {
-    return optionalFlippedTranslation2d(translation, alliance, () -> true);
   }
 }

--- a/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
+++ b/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
@@ -264,23 +264,29 @@ public class AllianceFlipUtil {
     return optionalFlippedPose2d(pose, alliance, () -> true);
   }
 
-    /**
+  /**
    * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; based on a
    * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Translation2d&gt;
    *
    * @param translationOpt The translation to flip
    * @param allianceOpt The current alliance
    * @param doFlip Returns true if flipping based on the alliance should be done
-   * @return empty if the alliance is empty; the original translation optional if the alliance is blue or
-   *     doFlip is false; the flipped translation optional if the alliance is red and doFlip is true
+   * @return empty if the alliance is empty; the original translation optional if the alliance is
+   *     blue or doFlip is false; the flipped translation optional if the alliance is red and doFlip
+   *     is true
    */
   public static Supplier<Optional<Translation2d>> optionalFlippedTranslation2d(
-      Optional<Translation2d> translationOpt, Supplier<Optional<Alliance>> allianceOpt, BooleanSupplier doFlip) {
+      Optional<Translation2d> translationOpt,
+      Supplier<Optional<Alliance>> allianceOpt,
+      BooleanSupplier doFlip) {
     return () ->
         doFlip.getAsBoolean()
             ? allianceOpt
                 .get()
-                .flatMap(ally -> translationOpt.map(translation -> ally == Alliance.Red ? flip(translation) : translation))
+                .flatMap(
+                    ally ->
+                        translationOpt.map(
+                            translation -> ally == Alliance.Red ? flip(translation) : translation))
             : translationOpt;
   }
 
@@ -290,8 +296,8 @@ public class AllianceFlipUtil {
    *
    * @param translation The translation to flip
    * @param alliance The current alliance
-   * @return empty if the alliance is empty; the original translation if the alliance is blue; the flipped
-   *     translation if the alliance is red
+   * @return empty if the alliance is empty; the original translation if the alliance is blue; the
+   *     flipped translation if the alliance is red
    */
   public static Supplier<Optional<Translation2d>> optionalFlippedTranslation2d(
       Optional<Translation2d> translation, Supplier<Optional<Alliance>> alliance) {

--- a/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
+++ b/choreolib/src/main/java/choreo/util/AllianceFlipUtil.java
@@ -240,7 +240,7 @@ public class AllianceFlipUtil {
    * @return empty if the alliance is empty; the original pose optional if the alliance is blue or
    *     doFlip is false; the flipped pose optional if the alliance is red and doFlip is true
    */
-  public static Supplier<Optional<Pose2d>> optionalFlipped(
+  public static Supplier<Optional<Pose2d>> optionalFlippedPose2d(
       Optional<Pose2d> poseOpt, Supplier<Optional<Alliance>> allianceOpt, BooleanSupplier doFlip) {
     return () ->
         doFlip.getAsBoolean()
@@ -259,8 +259,42 @@ public class AllianceFlipUtil {
    * @return empty if the alliance is empty; the original pose if the alliance is blue; the flipped
    *     pose if the alliance is red
    */
-  public static Supplier<Optional<Pose2d>> optionalFlipped(
+  public static Supplier<Optional<Pose2d>> optionalFlippedPose2d(
       Optional<Pose2d> pose, Supplier<Optional<Alliance>> alliance) {
-    return optionalFlipped(pose, alliance, () -> true);
+    return optionalFlippedPose2d(pose, alliance, () -> true);
+  }
+
+    /**
+   * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; based on a
+   * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Translation2d&gt;
+   *
+   * @param translationOpt The translation to flip
+   * @param allianceOpt The current alliance
+   * @param doFlip Returns true if flipping based on the alliance should be done
+   * @return empty if the alliance is empty; the original translation optional if the alliance is blue or
+   *     doFlip is false; the flipped translation optional if the alliance is red and doFlip is true
+   */
+  public static Supplier<Optional<Translation2d>> optionalFlippedTranslation2d(
+      Optional<Translation2d> translationOpt, Supplier<Optional<Alliance>> allianceOpt, BooleanSupplier doFlip) {
+    return () ->
+        doFlip.getAsBoolean()
+            ? allianceOpt
+                .get()
+                .flatMap(ally -> translationOpt.map(translation -> ally == Alliance.Red ? flip(translation) : translation))
+            : translationOpt;
+  }
+
+  /**
+   * Creates a Supplier&lt;Optional&lt;Translation2d&gt;&gt; based on a
+   * Supplier&lt;Optional&lt;Alliance&gt;&gt; and original Optional&lt;Translation2d&gt;
+   *
+   * @param translation The translation to flip
+   * @param alliance The current alliance
+   * @return empty if the alliance is empty; the original translation if the alliance is blue; the flipped
+   *     translation if the alliance is red
+   */
+  public static Supplier<Optional<Translation2d>> optionalFlippedTranslation2d(
+      Optional<Translation2d> translation, Supplier<Optional<Alliance>> alliance) {
+    return optionalFlippedTranslation2d(translation, alliance, () -> true);
   }
 }

--- a/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
+++ b/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
@@ -92,6 +92,5 @@ public class PoseFlippingTest {
         factory.trajectory(trajectory, factory.newRoutine("testroutine"));
     testPoseProperlyFlipped(start, startFlipped, autoTrajectory::getInitialPose);
     testPoseProperlyFlipped(end, endFlipped, autoTrajectory::getFinalPose);
-
   }
 }

--- a/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
+++ b/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
@@ -91,8 +91,7 @@ public class PoseFlippingTest {
     AutoTrajectory autoTrajectory =
         factory.trajectory(trajectory, factory.newRoutine("testroutine"));
     testPoseProperlyFlipped(start, startFlipped, autoTrajectory::getInitialPose);
-    testPoseProperlyFlipped(start, startFlipped, autoTrajectory.getInitialPoseSupplier());
     testPoseProperlyFlipped(end, endFlipped, autoTrajectory::getFinalPose);
-    testPoseProperlyFlipped(end, endFlipped, autoTrajectory.getFinalPoseSupplier());
+
   }
 }


### PR DESCRIPTION
Renamed atPose() triggers as atTranslation(), added new atPose() that requires rotation tolerance as well.
Fixed logic in those triggers that sampled an alliance-dependent pose too early
Made the triggers and(active()).