### PR TITLE
[choreolib] Pin WPILib version to development build

### DIFF
--- a/choreolib/build.gradle
+++ b/choreolib/build.gradle
@@ -27,11 +27,13 @@ java {
 repositories {
     mavenCentral()
 }
-if (project.hasProperty('releaseMode')) {
-    wpilibRepositories.addAllReleaseRepositories(project)
-} else {
-    wpilibRepositories.addAllDevelopmentRepositories(project)
-}
+// TODO: revert once WPILib releases 2025.1.1-beta-3
+wpilibRepositories.addAllDevelopmentRepositories(project)
+// if (project.hasProperty('releaseMode')) {
+//     wpilibRepositories.addAllReleaseRepositories(project)
+// } else {
+//     wpilibRepositories.addAllDevelopmentRepositories(project)
+// }
 
 // Apply C++ configuration
 apply from: 'config.gradle'

--- a/choreolib/config.gradle
+++ b/choreolib/config.gradle
@@ -8,7 +8,9 @@ nativeUtils.withCrossLinuxArm64()
 nativeUtils {
     wpi {
         configureDependencies {
-            wpiVersion = "2025.+"
+            // TODO: Revert once WPILib releases 2025.1.1-beta-3
+            wpiVersion = "2025.1.1-beta-2-36-g882233b"
+            // wpiVersion = "2025.+"
             niLibVersion = "2025.0.0"
         }
     }


### PR DESCRIPTION
Normally, ChoreoLib CI targets WPILib development builds in PRs and WPILib releases in tagged releases. WPILib recently upgraded to Bookworm but hasn't made a release yet. This means PR builds must target Bookworm to pass, and release builds must target Bullseye to pass.

Pinning to a WPILib release makes us target Bullseye for all builds. This would make us incompatible with the libraries in the next WPILib release we're bundled in.

Pinning to a specific development build makes us target Bookworm for all builds. This fixes the compatibility issue but means our beta release won't be reproducible after WPILib does its yearly development artifact purge.

This PR pins to a WPILib development version since it's less problematic in the near term, and we don't expect needing to rebuild old beta releases.