### PR TITLE
[choreolib] Add AutoTrajectory.resetOdometry()

### DIFF
--- a/choreolib/src/main/java/choreo/Choreo.java
+++ b/choreolib/src/main/java/choreo/Choreo.java
@@ -329,6 +329,8 @@ public final class Choreo {
    * @param <SampleType> The type of samples in the trajectory.
    * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
    *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
    * @param controller A function that receives the current {@link SampleType} and controls the
    *     robot.
    * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
@@ -343,12 +345,14 @@ public final class Choreo {
    */
   public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       BooleanSupplier useAllianceFlipping,
       Subsystem driveSubsystem,
       AutoBindings bindings) {
     return new AutoFactory(
         requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
+        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
         requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
         requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
         requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),
@@ -362,6 +366,8 @@ public final class Choreo {
    * @param <SampleType> The type of samples in the trajectory.
    * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
    *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
    * @param controller A function that receives the current {@link SampleType} and controls the
    *     robot.
    * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
@@ -378,6 +384,7 @@ public final class Choreo {
    */
   public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       BooleanSupplier useAllianceFlipping,
       Subsystem driveSubsystem,
@@ -385,6 +392,7 @@ public final class Choreo {
       TrajectoryLogger<SampleType> trajectoryLogger) {
     return new AutoFactory(
         requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
+        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
         requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
         requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
         requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),
@@ -398,6 +406,8 @@ public final class Choreo {
    * @param <SampleType> The type of samples in the trajectory.
    * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
    *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
    * @param controller A function that receives the current {@link SampleType} and controls the
    *     robot.
    * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
@@ -416,6 +426,7 @@ public final class Choreo {
    */
   public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       Subsystem driveSubsystem,
       BooleanSupplier useAllianceFlipping,
@@ -424,6 +435,7 @@ public final class Choreo {
       Supplier<Optional<Alliance>> alliance) {
     return new AutoFactory(
         requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
+        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
         requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
         requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
         requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),

--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -94,6 +94,7 @@ public class AutoFactory {
 
   private final TrajectoryCache trajectoryCache = new TrajectoryCache();
   private final Supplier<Pose2d> poseSupplier;
+  private final Consumer<Pose2d> resetOdometry;
   private final Consumer<? extends TrajectorySample<?>> controller;
   private final Supplier<Optional<Alliance>> alliance;
   private final BooleanSupplier useAllianceFlipping;
@@ -107,6 +108,7 @@ public class AutoFactory {
    *
    * @param <SampleType> {@link Choreo#createAutoFactory}
    * @param poseSupplier {@link Choreo#createAutoFactory}
+   * @param resetOdometry {@link Choreo#createAutoFactory}
    * @param controller {@link Choreo#createAutoFactory}
    * @param driveSubsystem {@link Choreo#createAutoFactory}
    * @param useAllianceFlipping {@link Choreo#createAutoFactory}
@@ -116,6 +118,7 @@ public class AutoFactory {
    */
   public <SampleType extends TrajectorySample<SampleType>> AutoFactory(
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       Subsystem driveSubsystem,
       BooleanSupplier useAllianceFlipping,
@@ -123,6 +126,7 @@ public class AutoFactory {
       Optional<TrajectoryLogger<SampleType>> trajectoryLogger,
       Supplier<Optional<Alliance>> alliance) {
     this.poseSupplier = poseSupplier;
+    this.resetOdometry = resetOdometry;
     this.controller = controller;
     this.driveSubsystem = driveSubsystem;
     this.useAllianceFlipping = useAllianceFlipping;
@@ -139,6 +143,7 @@ public class AutoFactory {
    *
    * @param <SampleType> {@link Choreo#createAutoFactory}
    * @param poseSupplier {@link Choreo#createAutoFactory}
+   * @param resetOdometry {@link Choreo#createAutoFactory}
    * @param controller {@link Choreo#createAutoFactory}
    * @param driveSubsystem {@link Choreo#createAutoFactory}
    * @param useAllianceFlipping {@link Choreo#createAutoFactory}
@@ -147,6 +152,7 @@ public class AutoFactory {
    */
   public <SampleType extends TrajectorySample<SampleType>> AutoFactory(
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       Subsystem driveSubsystem,
       BooleanSupplier useAllianceFlipping,
@@ -154,6 +160,7 @@ public class AutoFactory {
       Optional<TrajectoryLogger<SampleType>> trajectoryLogger) {
     this(
         poseSupplier,
+        resetOdometry,
         controller,
         driveSubsystem,
         useAllianceFlipping,
@@ -237,6 +244,7 @@ public class AutoFactory {
         trajectory.name(),
         solidTrajectory,
         poseSupplier,
+        resetOdometry,
         solidController,
         useAllianceFlipping,
         alliance,
@@ -301,6 +309,39 @@ public class AutoFactory {
   public <SampleType extends TrajectorySample<SampleType>> Command trajectoryCommand(
       Trajectory<SampleType> trajectory) {
     return trajectory(trajectory, VOID_ROUTINE).cmd();
+  }
+
+  /**
+   * Creates a command that resets the robot's odometry to the start of a trajectory.
+   *
+   * @param trajectoryName The name of the trajectory to use.
+   * @return A command that resets the robot's odometry.
+   */
+  public Command resetOdometry(String trajectoryName) {
+    return trajectory(trajectoryName, VOID_ROUTINE).resetOdometry();
+  }
+
+  /**
+   * Creates a command that resets the robot's odometry to the start of a trajectory.
+   *
+   * @param trajectoryName The name of the trajectory to use.
+   * @param splitIndex The index of the split trajectory to use.
+   * @return A command that resets the robot's odometry.
+   */
+  public Command resetOdometry(String trajectoryName, final int splitIndex) {
+    return trajectory(trajectoryName, splitIndex, VOID_ROUTINE).resetOdometry();
+  }
+
+  /**
+   * Creates a command that resets the robot's odometry to the start of a trajectory.
+   *
+   * @param <SampleType> The type of the trajectory samples.
+   * @param trajectory The trajectory to use.
+   * @return A command that resets the robot's odometry.
+   */
+  public <SampleType extends TrajectorySample<SampleType>> Command resetOdometry(
+      Trajectory<SampleType> trajectory) {
+    return trajectory(trajectory, VOID_ROUTINE).resetOdometry();
   }
 
   /**

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.FunctionalCommand;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -45,6 +46,7 @@ public class AutoTrajectory {
   private final Trajectory<? extends TrajectorySample<?>> trajectory;
   private final TrajectoryLogger<? extends TrajectorySample<?>> trajectoryLogger;
   private final Supplier<Pose2d> poseSupplier;
+  private final Consumer<Pose2d> resetOdometry;
   private final Consumer<? extends TrajectorySample<?>> controller;
   private final BooleanSupplier useAllianceFlipping;
   private final Supplier<Optional<Alliance>> alliance;
@@ -81,6 +83,7 @@ public class AutoTrajectory {
       String name,
       Trajectory<SampleType> trajectory,
       Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
       BooleanSupplier useAllianceFlipping,
       Supplier<Optional<Alliance>> alliance,
@@ -91,6 +94,7 @@ public class AutoTrajectory {
     this.name = name;
     this.trajectory = trajectory;
     this.poseSupplier = poseSupplier;
+    this.resetOdometry = resetOdometry;
     this.controller = controller;
     this.useAllianceFlipping = useAllianceFlipping;
     this.alliance = alliance;
@@ -258,6 +262,28 @@ public class AutoTrajectory {
       return Optional.empty();
     }
     return trajectory.getFinalPose(doFlip());
+  }
+
+  /**
+   * Creates a command that resets the robot's odometry to the start of this trajectory.
+   *
+   * @return A command that resets the robot's odometry.
+   */
+  public Command resetOdometry() {
+    return Commands.either(
+            Commands.runOnce(() -> resetOdometry.accept(getInitialPose().get()), driveSubsystem),
+            Commands.runOnce(
+                    () -> {
+                      DriverStation.reportError(
+                          "[Choreo] Unable to retrieve initial pose from trajectory \""
+                              + name
+                              + "\"",
+                          false);
+                      routine.kill();
+                    })
+                .andThen(Commands.idle()),
+            () -> getInitialPose().isPresent())
+        .withName("Trajectory_ResetOdometry_" + name);
   }
 
   /**

--- a/choreolib/src/test/java/choreo/auto/AutoTestHelper.java
+++ b/choreolib/src/test/java/choreo/auto/AutoTestHelper.java
@@ -17,6 +17,7 @@ public class AutoTestHelper {
     AtomicReference<Pose2d> pose = new AtomicReference<>(new Pose2d());
     return new AutoFactory(
         () -> pose.get(),
+        newPose -> pose.set(newPose),
         sample -> pose.set(sample.getPose()),
         new Subsystem() {},
         useAllianceFlipping,


### PR DESCRIPTION
Enforces that routines or command compositions will not execute if odometry is not seeded (trajectory cannot be loaded, is empty, or alliance is unknown), and reduces complexity for the user.

See the [this message](https://discord.com/channels/975739302933856277/1013180308117536788/1315321921222742067) in Discord for context.

Usage:
```java
AutoFactory autoFactory = Choreo.createAutoFactory(
  driveSubsystem::getPose,
  driveSubsystem::resetOdometry, // Consumer<Pose2d>
  driveSubsystem::followTrajectory
  // ...
);

// Using AutoRoutine
AutoRoutine routine = autoFactory.newRoutine("example");
AutoTrajectory myTrajectory = routine.trajectory("myTrajectory");
routine.running().onTrue(myTrajectory.resetOdometry().andThen(myTrajectory.cmd()));

// Using command composition
Commands.sequence(
  autoFactory.resetOdometry("myTrajectory"),
  autoFactory.trajectoryCommand("myTrajectory")
);
```

Still a little conflicted on the name. `seedOdometry()` feels a little more appropriate, however `resetOdometry()` is the nomenclature in the WPILib API so it's probably the better choice. Some interesting behavior to `AutoRoutine` could also be added to make resetting odometry automatic, though I'm also not sure how I feel about that. Feedback is welcome.