### PR TITLE
[choreolib] Replace Choreo.createAutoFactory method with constructor

### DIFF
--- a/choreolib/src/main/java/choreo/Choreo.java
+++ b/choreolib/src/main/java/choreo/Choreo.java
@@ -5,7 +5,6 @@ package choreo;
 import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 import static edu.wpi.first.wpilibj.Alert.AlertType.kError;
 
-import choreo.auto.AutoFactory;
 import choreo.trajectory.DifferentialSample;
 import choreo.trajectory.EventMarker;
 import choreo.trajectory.ProjectFile;

--- a/choreolib/src/main/java/choreo/Choreo.java
+++ b/choreolib/src/main/java/choreo/Choreo.java
@@ -324,15 +324,6 @@ public final class Choreo {
   }
 
   /**
-   * @Deprecated Use ```new AutoFactory()``` instead.
-   */
-  @Deprecated(forRemoval = true)
-  public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory() {
-    throw new RuntimeException(
-        "Choreo.createAutoFactory is no longer supported; use new AutoFactory() instead.");
-  }
-
-  /**
    * Creates an alert under the "Choreo" group.
    *
    * @param name The name of the alert

--- a/choreolib/src/main/java/choreo/Choreo.java
+++ b/choreolib/src/main/java/choreo/Choreo.java
@@ -5,11 +5,7 @@ package choreo;
 import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
 import static edu.wpi.first.wpilibj.Alert.AlertType.kError;
 
-import choreo.auto.AutoChooser;
 import choreo.auto.AutoFactory;
-import choreo.auto.AutoFactory.AutoBindings;
-import choreo.auto.AutoRoutine;
-import choreo.auto.AutoTrajectory;
 import choreo.trajectory.DifferentialSample;
 import choreo.trajectory.EventMarker;
 import choreo.trajectory.ProjectFile;
@@ -22,13 +18,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.hal.HAL;
-import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Filesystem;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Subsystem;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -41,10 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /** Utilities to load and follow Choreo Trajectories */
 public final class Choreo {
@@ -335,124 +324,12 @@ public final class Choreo {
   }
 
   /**
-   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
-   *
-   * @param <SampleType> The type of samples in the trajectory.
-   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
-   *     robot.
-   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
-   *     robot's odometry to.
-   * @param controller A function that receives the current {@link SampleType} and controls the
-   *     robot.
-   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
-   *     Command}s.
-   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
-   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
-   *     be called every loop during the command.
-   * @param bindings Universal trajectory event bindings.
-   * @return An {@link AutoFactory} that can be used to create {@link AutoRoutine} and {@link
-   *     AutoTrajectory}.
-   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
+   * @Deprecated Use ```new AutoFactory()``` instead.
    */
-  public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
-      Supplier<Pose2d> poseSupplier,
-      Consumer<Pose2d> resetOdometry,
-      Consumer<SampleType> controller,
-      BooleanSupplier useAllianceFlipping,
-      Subsystem driveSubsystem,
-      AutoBindings bindings) {
-    return new AutoFactory(
-        requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
-        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
-        requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
-        requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
-        requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),
-        requireNonNullParam(bindings, "bindings", "Choreo.createAutoFactory"),
-        Optional.empty());
-  }
-
-  /**
-   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
-   *
-   * @param <SampleType> The type of samples in the trajectory.
-   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
-   *     robot.
-   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
-   *     robot's odometry to.
-   * @param controller A function that receives the current {@link SampleType} and controls the
-   *     robot.
-   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
-   *     Command}s.
-   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
-   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
-   *     be called every loop during the command.
-   * @param bindings Universal trajectory event bindings.
-   * @param trajectoryLogger A {@link TrajectoryLogger} to log {@link Trajectory} as they start and
-   *     finish.
-   * @return An {@link AutoFactory} that can be used to create {@link AutoRoutine} and {@link
-   *     AutoTrajectory}.
-   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
-   */
-  public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
-      Supplier<Pose2d> poseSupplier,
-      Consumer<Pose2d> resetOdometry,
-      Consumer<SampleType> controller,
-      BooleanSupplier useAllianceFlipping,
-      Subsystem driveSubsystem,
-      AutoBindings bindings,
-      TrajectoryLogger<SampleType> trajectoryLogger) {
-    return new AutoFactory(
-        requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
-        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
-        requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
-        requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
-        requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),
-        requireNonNullParam(bindings, "bindings", "Choreo.createAutoFactory"),
-        Optional.of(trajectoryLogger));
-  }
-
-  /**
-   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
-   *
-   * @param <SampleType> The type of samples in the trajectory.
-   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
-   *     robot.
-   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
-   *     robot's odometry to.
-   * @param controller A function that receives the current {@link SampleType} and controls the
-   *     robot.
-   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
-   *     Command}s.
-   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
-   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
-   *     be called every loop during the command.
-   * @param bindings Universal trajectory event bindings.
-   * @param trajectoryLogger A {@link TrajectoryLogger} to log {@link Trajectory} as they start and
-   *     finish.
-   * @param alliance A custom supplier of the current alliance to use instead of {@link
-   *     DriverStation#getAlliance}.
-   * @return An {@link AutoFactory} that can be used to create {@link AutoRoutine} and {@link
-   *     AutoTrajectory}.
-   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
-   */
-  public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory(
-      Supplier<Pose2d> poseSupplier,
-      Consumer<Pose2d> resetOdometry,
-      Consumer<SampleType> controller,
-      Subsystem driveSubsystem,
-      BooleanSupplier useAllianceFlipping,
-      AutoBindings bindings,
-      TrajectoryLogger<SampleType> trajectoryLogger,
-      Supplier<Optional<Alliance>> alliance) {
-    return new AutoFactory(
-        requireNonNullParam(poseSupplier, "poseSupplier", "Choreo.createAutoFactory"),
-        requireNonNullParam(resetOdometry, "resetOdometry", "Choreo.createAutoFactory"),
-        requireNonNullParam(controller, "controller", "Choreo.createAutoFactory"),
-        requireNonNullParam(driveSubsystem, "driveSubsystem", "Choreo.createAutoFactory"),
-        requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "Choreo.createAutoFactory"),
-        requireNonNullParam(bindings, "bindings", "Choreo.createAutoFactory"),
-        Optional.of(trajectoryLogger),
-        requireNonNullParam(alliance, "alliance", "Choreo.createAutoFactory"));
+  @Deprecated(forRemoval = true)
+  public static <SampleType extends TrajectorySample<SampleType>> AutoFactory createAutoFactory() {
+    throw new RuntimeException(
+        "Choreo.createAutoFactory is no longer supported; use new AutoFactory() instead.");
   }
 
   /**

--- a/choreolib/src/main/java/choreo/auto/AutoFactory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoFactory.java
@@ -2,7 +2,8 @@
 
 package choreo.auto;
 
-import choreo.Choreo;
+import static edu.wpi.first.util.ErrorMessages.requireNonNullParam;
+
 import choreo.Choreo.TrajectoryCache;
 import choreo.Choreo.TrajectoryLogger;
 import choreo.trajectory.SwerveSample;
@@ -100,72 +101,129 @@ public class AutoFactory {
   private final BooleanSupplier useAllianceFlipping;
   private final Subsystem driveSubsystem;
   private final AutoBindings bindings = new AutoBindings();
-  private final Optional<TrajectoryLogger<? extends TrajectorySample<?>>> trajectoryLogger;
+  private final TrajectoryLogger<? extends TrajectorySample<?>> trajectoryLogger;
 
   /**
-   * It is recommended to use the {@link Choreo#createAutoFactory} to create a new instance of this
-   * class.
+   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
    *
-   * @param <SampleType> {@link Choreo#createAutoFactory}
-   * @param poseSupplier {@link Choreo#createAutoFactory}
-   * @param resetOdometry {@link Choreo#createAutoFactory}
-   * @param controller {@link Choreo#createAutoFactory}
-   * @param driveSubsystem {@link Choreo#createAutoFactory}
-   * @param useAllianceFlipping {@link Choreo#createAutoFactory}
-   * @param bindings {@link Choreo#createAutoFactory}
-   * @param trajectoryLogger {@link Choreo#createAutoFactory}
-   * @param alliance {@link Choreo#createAutoFactory}
+   * @param <SampleType> The type of samples in the trajectory.
+   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
+   *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
+   * @param controller A function that receives the current {@link SampleType} and controls the
+   *     robot.
+   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
+   *     Command}s.
+   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
+   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
+   *     be called every loop during the command.
+   * @param bindings Universal trajectory event bindings.
+   * @param trajectoryLogger A {@link TrajectoryLogger} to log {@link Trajectory} as they start and
+   *     finish.
+   * @param alliance A custom supplier of the current alliance to use instead of {@link
+   *     DriverStation#getAlliance}.
+   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
    */
   public <SampleType extends TrajectorySample<SampleType>> AutoFactory(
       Supplier<Pose2d> poseSupplier,
       Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
-      Subsystem driveSubsystem,
       BooleanSupplier useAllianceFlipping,
+      Subsystem driveSubsystem,
       AutoBindings bindings,
-      Optional<TrajectoryLogger<SampleType>> trajectoryLogger,
+      TrajectoryLogger<SampleType> trajectoryLogger,
       Supplier<Optional<Alliance>> alliance) {
+    requireNonNullParam(poseSupplier, "poseSupplier", "AutoFactory");
+    requireNonNullParam(resetOdometry, "resetOdometry", "AutoFactory");
+    requireNonNullParam(controller, "controller", "AutoFactory");
+    requireNonNullParam(driveSubsystem, "driveSubsystem", "AutoFactory");
+    requireNonNullParam(useAllianceFlipping, "useAllianceFlipping", "AutoFactory");
+    requireNonNullParam(bindings, "bindings", "AutoFactory");
+
     this.poseSupplier = poseSupplier;
     this.resetOdometry = resetOdometry;
     this.controller = controller;
     this.driveSubsystem = driveSubsystem;
     this.useAllianceFlipping = useAllianceFlipping;
     this.bindings.merge(bindings);
-    this.trajectoryLogger =
-        trajectoryLogger.map(logger -> (TrajectoryLogger<? extends TrajectorySample<?>>) logger);
+    this.trajectoryLogger = trajectoryLogger;
     this.alliance = alliance;
     HAL.report(tResourceType.kResourceType_ChoreoTrigger, 1);
   }
 
   /**
-   * It is recommended to use the {@link Choreo#createAutoFactory} to create a new instance of this
-   * class.
+   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
    *
-   * @param <SampleType> {@link Choreo#createAutoFactory}
-   * @param poseSupplier {@link Choreo#createAutoFactory}
-   * @param resetOdometry {@link Choreo#createAutoFactory}
-   * @param controller {@link Choreo#createAutoFactory}
-   * @param driveSubsystem {@link Choreo#createAutoFactory}
-   * @param useAllianceFlipping {@link Choreo#createAutoFactory}
-   * @param bindings {@link Choreo#createAutoFactory}
-   * @param trajectoryLogger {@link Choreo#createAutoFactory}
+   * @param <SampleType> The type of samples in the trajectory.
+   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
+   *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
+   * @param controller A function that receives the current {@link SampleType} and controls the
+   *     robot.
+   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
+   *     Command}s.
+   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
+   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
+   *     be called every loop during the command.
+   * @param bindings Universal trajectory event bindings.
+   * @param trajectoryLogger A {@link TrajectoryLogger} to log {@link Trajectory} as they start and
+   *     finish.
+   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
    */
   public <SampleType extends TrajectorySample<SampleType>> AutoFactory(
       Supplier<Pose2d> poseSupplier,
       Consumer<Pose2d> resetOdometry,
       Consumer<SampleType> controller,
-      Subsystem driveSubsystem,
       BooleanSupplier useAllianceFlipping,
+      Subsystem driveSubsystem,
       AutoBindings bindings,
-      Optional<TrajectoryLogger<SampleType>> trajectoryLogger) {
+      TrajectoryLogger<SampleType> trajectoryLogger) {
     this(
         poseSupplier,
         resetOdometry,
         controller,
-        driveSubsystem,
         useAllianceFlipping,
+        driveSubsystem,
         bindings,
         trajectoryLogger,
+        DriverStation::getAlliance);
+  }
+
+  /**
+   * Create a factory that can be used to create {@link AutoRoutine} and {@link AutoTrajectory}.
+   *
+   * @param <SampleType> The type of samples in the trajectory.
+   * @param poseSupplier A function that returns the current field-relative {@link Pose2d} of the
+   *     robot.
+   * @param resetOdometry A function that receives a field-relative {@link Pose2d} to reset the
+   *     robot's odometry to.
+   * @param controller A function that receives the current {@link SampleType} and controls the
+   *     robot.
+   * @param driveSubsystem The drive {@link Subsystem} to require for {@link AutoTrajectory} {@link
+   *     Command}s.
+   * @param useAllianceFlipping If this returns true, when on the red alliance, the path will be
+   *     mirrored to the opposite side, while keeping the same coordinate system origin. This will
+   *     be called every loop during the command.
+   * @param bindings Universal trajectory event bindings.
+   * @see AutoChooser using this factory with AutoChooser to generate auto routines.
+   */
+  public <SampleType extends TrajectorySample<SampleType>> AutoFactory(
+      Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetOdometry,
+      Consumer<SampleType> controller,
+      BooleanSupplier useAllianceFlipping,
+      Subsystem driveSubsystem,
+      AutoBindings bindings) {
+    this(
+        poseSupplier,
+        resetOdometry,
+        controller,
+        useAllianceFlipping,
+        driveSubsystem,
+        bindings,
+        (sample, isStart) -> {},
         DriverStation::getAlliance);
   }
 
@@ -236,8 +294,6 @@ public class AutoFactory {
     // type solidify everything
     final Trajectory<ST> solidTrajectory = trajectory;
     final Consumer<ST> solidController = (Consumer<ST>) this.controller;
-    final Optional<TrajectoryLogger<ST>> solidLogger =
-        this.trajectoryLogger.map(logger -> (TrajectoryLogger<ST>) logger);
     return new AutoTrajectory(
         trajectory.name(),
         solidTrajectory,
@@ -246,7 +302,7 @@ public class AutoFactory {
         solidController,
         useAllianceFlipping,
         alliance,
-        solidLogger,
+        (TrajectoryLogger<ST>) trajectoryLogger,
         driveSubsystem,
         routine,
         bindings);

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -56,22 +56,6 @@ public class AutoTrajectory {
       Choreo.multiAlert(
           causes -> "Unable to get initial pose for trajectories " + causes + ".", kError);
 
-  public static Trigger anyDone(AutoTrajectory... trajectories) {
-    var trigger = trajectories[0].done();
-    for (int i = 1; i < trajectories.length; i++) {
-      trigger = trigger.or(trajectories[i].done());
-    }
-    return trigger;
-  }
-
-  public static Trigger allDone(AutoTrajectory... trajectories) {
-    var trigger = trajectories[0].done();
-    for (int i = 1; i < trajectories.length; i++) {
-      trigger = trigger.and(trajectories[i].done());
-    }
-    return trigger;
-  }
-
   private static final double DEFAULT_TOLERANCE_METERS = Units.inchesToMeters(3);
   private static final double DEFAULT_TOLERANCE_RADIANS = Units.degreesToRadians(3);
   private final String name;

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -56,6 +56,22 @@ public class AutoTrajectory {
       Choreo.multiAlert(
           causes -> "Unable to get initial pose for trajectories " + causes + ".", kError);
 
+  public static Trigger anyDone(AutoTrajectory... trajectories) {
+    var trigger = trajectories[0].done();
+    for (int i = 1; i < trajectories.length; i++) {
+      trigger = trigger.or(trajectories[i].done());
+    }
+    return trigger;
+  }
+
+  public static Trigger allDone(AutoTrajectory... trajectories) {
+    var trigger = trajectories[0].done();
+    for (int i = 1; i < trajectories.length; i++) {
+      trigger = trigger.and(trajectories[i].done());
+    }
+    return trigger;
+  }
+
   private static final double DEFAULT_TOLERANCE_METERS = Units.inchesToMeters(3);
   private static final double DEFAULT_TOLERANCE_RADIANS = Units.degreesToRadians(3);
   private final String name;
@@ -94,7 +110,7 @@ public class AutoTrajectory {
    * @param trajectoryLogger Optional trajectory logger.
    * @param driveSubsystem Drive subsystem.
    * @param routine Event loop.
-   * @param bindings {@link Choreo#createAutoFactory}
+   * @param bindings {@link AutoFactory}
    */
   <SampleType extends TrajectorySample<SampleType>> AutoTrajectory(
       String name,
@@ -104,7 +120,7 @@ public class AutoTrajectory {
       Consumer<SampleType> controller,
       BooleanSupplier useAllianceFlipping,
       Supplier<Optional<Alliance>> alliance,
-      Optional<TrajectoryLogger<SampleType>> trajectoryLogger,
+      TrajectoryLogger<SampleType> trajectoryLogger,
       Subsystem driveSubsystem,
       AutoRoutine routine,
       AutoBindings bindings) {
@@ -118,12 +134,7 @@ public class AutoTrajectory {
     this.driveSubsystem = driveSubsystem;
     this.routine = routine;
     this.offTrigger = new Trigger(routine.loop(), () -> false);
-    this.trajectoryLogger =
-        trajectoryLogger.isPresent()
-            ? trajectoryLogger.get()
-            : new TrajectoryLogger<SampleType>() {
-              public void accept(Trajectory<SampleType> t, Boolean u) {}
-            };
+    this.trajectoryLogger = trajectoryLogger;
 
     bindings.getBindings().forEach((key, value) -> active().and(atTime(key)).onTrue(value));
   }

--- a/choreolib/src/test/java/choreo/auto/AutoTestHelper.java
+++ b/choreolib/src/test/java/choreo/auto/AutoTestHelper.java
@@ -2,7 +2,6 @@
 
 package choreo.auto;
 
-import choreo.auto.AutoFactory.AutoBindings;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj2.command.Subsystem;
@@ -19,10 +18,10 @@ public class AutoTestHelper {
         () -> pose.get(),
         newPose -> pose.set(newPose),
         sample -> pose.set(sample.getPose()),
-        new Subsystem() {},
         useAllianceFlipping,
-        new AutoBindings(),
-        Optional.empty(),
+        new Subsystem() {},
+        new AutoFactory.AutoBindings(),
+        (sample, isStart) -> {},
         alliance);
   }
 

--- a/docs/choreolib/auto-factory.md
+++ b/docs/choreolib/auto-factory.md
@@ -16,7 +16,7 @@ class Robot extends TimedRobot {
   private final AutoFactory autoFactory;
 
   public Robot() {
-    autoFactory = Choreo.createAutoFactory(
+    autoFactory = new AutoFactory(
       drive, // The drive subsystem
       drive::getPose, // A function that returns the current robot pose
       drive::choreoController, // The controller for the drive subsystem


### PR DESCRIPTION
Choreo.createAutoFactory() didn't do anything that the constructors couldn't already do.

Note: I still kept in a no-args createAutoFactory() method to give a proper deprecation notice to people who were using the choreolib betas, just in case of confusion.