### PR TITLE
[choreolib-java] Move AutoTrajectory.resetOdometry() to AutoRoutine

### DIFF
--- a/choreolib/src/main/java/choreo/auto/AutoRoutine.java
+++ b/choreolib/src/main/java/choreo/auto/AutoRoutine.java
@@ -194,6 +194,16 @@ public class AutoRoutine {
   }
 
   /**
+   * Creates a command that resets the robot's odometry to the start of a trajectory.
+   *
+   * @param trajectory The trajectory to use.
+   * @return A command that resets the robot's odometry.
+   */
+  public Command resetOdometry(AutoTrajectory trajectory) {
+    return trajectory.resetOdometry();
+  }
+
+  /**
    * Creates a command that will poll this event loop and reset it when it is cancelled.
    *
    * <p>The command will end instantly and kill the routine if the alliance supplier returns an

--- a/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
+++ b/choreolib/src/main/java/choreo/auto/AutoTrajectory.java
@@ -219,6 +219,24 @@ public class AutoTrajectory {
   }
 
   /**
+   * Creates a command that resets the robot's odometry to the start of this trajectory.
+   *
+   * @return A command that resets the robot's odometry.
+   */
+  Command resetOdometry() {
+    return Commands.either(
+            Commands.runOnce(() -> resetOdometry.accept(getInitialPose().get()), driveSubsystem),
+            Commands.runOnce(
+                    () -> {
+                      noInitialPose.addCause(name);
+                      routine.kill();
+                    })
+                .andThen(Commands.idle()),
+            () -> getInitialPose().isPresent())
+        .withName("Trajectory_ResetOdometry_" + name);
+  }
+
+  /**
    * Will get the underlying {@link Trajectory} object.
    *
    * <p><b>WARNING:</b> This method is not type safe and should be used with caution. The sample
@@ -269,24 +287,6 @@ public class AutoTrajectory {
       return Optional.empty();
     }
     return trajectory.getFinalPose(doFlip());
-  }
-
-  /**
-   * Creates a command that resets the robot's odometry to the start of this trajectory.
-   *
-   * @return A command that resets the robot's odometry.
-   */
-  public Command resetOdometry() {
-    return Commands.either(
-            Commands.runOnce(() -> resetOdometry.accept(getInitialPose().get()), driveSubsystem),
-            Commands.runOnce(
-                    () -> {
-                      noInitialPose.addCause(name);
-                      routine.kill();
-                    })
-                .andThen(Commands.idle()),
-            () -> getInitialPose().isPresent())
-        .withName("Trajectory_ResetOdometry_" + name);
   }
 
   /**


### PR DESCRIPTION
Resolves #1010 
To save from extra dependency injection into `AutoRoutine` the implementation still exists as package private in `AutoTrajectory`. If that is not the desired solution I can make the necessary changes.