### PR TITLE
[ci] Update roboRIO docker container to 2025

### DIFF
--- a/.github/workflows/choreolib.yml
+++ b/.github/workflows/choreolib.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2024-22.04
+          - container: wpilib/roborio-cross-ubuntu:2025-22.04
             artifact-name: Athena
             build-options: -Ponlylinuxathena
 


### PR DESCRIPTION
The update to NativeUtils 2025.9.0 (#991) seems to cause c++ builds for the RIO to be skipped on the 2024 docker container. Updating to the 2025 docker container fixes this issue and builds c++ rio artifacts again.