### PR TITLE
Remove reference to Choreo being bundled with WPILib

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,5 @@
 # Installation
 
-- **note**: if you have already installed WPILib you should have Choreo installed.
-
 Start by downloading Choreo from **[Releases](https://github.com/SleipnirGroup/Choreo/releases)**
 
 ## Supported Systems


### PR DESCRIPTION
Choreo is no longer bundled with WPILib and thus this line is no longer accurate.