### PR TITLE
Add github token and persist-credentials:false to all actions/checkout

### DIFF
--- a/.github/workflows/choreolib.yml
+++ b/.github/workflows/choreolib.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Fetch all history and metadata
         run: |
@@ -87,6 +89,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Fetch all history and metadata
         run: git fetch --prune --unshallow
@@ -128,6 +132,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -142,6 +149,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: wpilibsuite/build-tools
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - uses: actions/download-artifact@v4
         with:
@@ -212,6 +221,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Configure Git Credentials
         run: |

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Fetch all history and metadata
         run: |
@@ -86,7 +88,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -105,6 +109,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
           fetch-depth: 0
 
       - name: Fetch all history and metadata
@@ -144,6 +150,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
           fetch-depth: 0
 
       - name: Fetch all history and metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,19 @@ jobs:
     runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CHOREOLIB_RELEASE_APP_ID }}
+          private-key: ${{ secrets.CHOREOLIB_RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
-          token: ${{ secrets.CHOREO_RELEASE_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
+
       - name: Install Python dependencies
         run: pip install tomlkit
 

--- a/.github/workflows/trajoptlib-cpp.yml
+++ b/.github/workflows/trajoptlib-cpp.yml
@@ -31,6 +31,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Install dependencies (Windows)
         uses: lukka/get-cmake@v3.29.3

--- a/.github/workflows/trajoptlib-rust.yml
+++ b/.github/workflows/trajoptlib-rust.yml
@@ -27,6 +27,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Install dependencies (Windows)
         uses: lukka/get-cmake@v3.29.3

--- a/.github/workflows/trajoptlib-sanitizers.yml
+++ b/.github/workflows/trajoptlib-sanitizers.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y ninja-build


### PR DESCRIPTION
https://yossarian.net/til/post/actions-checkout-can-leak-github-credentials/

Fortunately everything we could have leaked gets revoked at the end of the workflow, but I think this credential issue might be messing with our release version number updating workflow.