### PR TITLE
Simplify logic when receiving a successful generation in UI

### DIFF
--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -176,7 +176,6 @@ export const DocumentStore = types
 
       console.log(pathStore.serialize);
       const config = self.robotConfig.serialize;
-      const inputDriveType = self.type;
       pathStore.params.constraints
         .filter((constraint) => constraint.enabled)
         .forEach((constraint) => {

--- a/src/document/DocumentModel.tsx
+++ b/src/document/DocumentModel.tsx
@@ -254,30 +254,7 @@ export const DocumentStore = types
             const result: Trajectory = rust_trajectory as Trajectory;
             console.log(result);
             if (result.trajectory.samples.length == 0) throw "No trajectory";
-            self.history.startGroup(() => {
-              const newTrajectory = result.trajectory.samples;
-              if (inputDriveType === "Differential") {
-                pathStore.trajectory.setDifferentialSamples(
-                  newTrajectory as DifferentialSample[]
-                );
-              } else {
-                pathStore.trajectory.setSwerveSamples(
-                  newTrajectory as SwerveSample[]
-                );
-              }
-              pathStore.trajectory.setSplits(result.trajectory.splits);
-              pathStore.trajectory.setWaypoints(result.trajectory.waypoints);
-              pathStore.markers.forEach((m) => {
-                const index = m.from.trajectoryTargetIndex;
-                if (index === undefined) {
-                  m.from.setTargetTimestamp(undefined);
-                } else {
-                  m.from.setTargetTimestamp(result.trajectory.waypoints[index]);
-                }
-              });
-              pathStore.setSnapshot(result.snapshot);
-              self.history.stopGroup();
-            });
+            pathStore.processGenerationResult(result);
           },
           (e) => {
             tracing.error("generatePathPost:", e);

--- a/src/document/path/HolonomicPathStore.ts
+++ b/src/document/path/HolonomicPathStore.ts
@@ -151,11 +151,24 @@ export const HolonomicPathStore = types
   })
   .actions((self) => {
     return {
+      processGenerationResult(ser: Trajectory) {
+        self.trajectory.deserialize(ser.trajectory);
+        self.markers.forEach((m) => {
+          const index = m.from.trajectoryTargetIndex;
+          if (index === undefined) {
+            m.from.setTargetTimestamp(undefined);
+          } else {
+            m.from.setTargetTimestamp(ser.trajectory.waypoints[index]);
+          }
+        });
+        self.setSnapshot(ser.snapshot);
+      },
       deserialize(ser: Trajectory) {
         self.name = ser.name;
         self.snapshot = ser.snapshot;
         self.params.deserialize(ser.params);
         self.trajectory.deserialize(ser.trajectory);
+        self.markers.clear();
         ser.events.forEach((m) => {
           self.addEventMarker(m);
         });


### PR DESCRIPTION
This removes the need to use a group to keep this all in one undo step. It moves the logic to HolonomicPathStore and uses existing deserialization logic where possible.