### PR TITLE
Remove dimension tooltips

### DIFF
--- a/src/components/config/variables/VariablesConfigPanel.tsx
+++ b/src/components/config/variables/VariablesConfigPanel.tsx
@@ -1,7 +1,7 @@
 import { Add, Delete } from "@mui/icons-material";
-import { MenuItem, Select, SelectChangeEvent, Tooltip } from "@mui/material";
+import { MenuItem, Select, SelectChangeEvent, Tooltip, TooltipProps } from "@mui/material";
 import { observer } from "mobx-react";
-import { useMemo, useState } from "react";
+import { ReactElement, forwardRef, useMemo, useState } from "react";
 import { doc } from "../../../document/DocumentManager";
 import {
   DimensionName,
@@ -115,9 +115,7 @@ export const GeneralVariableAddPanel = observer(() => {
     >
       {DimensionNamesExt.map((entry) => (
         <MenuItem value={entry}>
-          <Tooltip disableInteractive title={DimensionsExt[entry].name}>
             {DimensionsExt[entry].icon()}
-          </Tooltip>
           <span style={{ width: "4px" }}></span>
           {DimensionsExt[entry].name}
         </MenuItem>

--- a/src/components/config/variables/VariablesConfigPanel.tsx
+++ b/src/components/config/variables/VariablesConfigPanel.tsx
@@ -1,7 +1,7 @@
 import { Add, Delete } from "@mui/icons-material";
-import { MenuItem, Select, SelectChangeEvent, Tooltip, TooltipProps } from "@mui/material";
+import { MenuItem, Select, SelectChangeEvent, Tooltip } from "@mui/material";
 import { observer } from "mobx-react";
-import { ReactElement, forwardRef, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { doc } from "../../../document/DocumentManager";
 import {
   DimensionName,
@@ -115,7 +115,7 @@ export const GeneralVariableAddPanel = observer(() => {
     >
       {DimensionNamesExt.map((entry) => (
         <MenuItem value={entry}>
-            {DimensionsExt[entry].icon()}
+          {DimensionsExt[entry].icon()}
           <span style={{ width: "4px" }}></span>
           {DimensionsExt[entry].name}
         </MenuItem>

--- a/src/document/ExpressionStore.tsx
+++ b/src/document/ExpressionStore.tsx
@@ -181,11 +181,7 @@ export const DimensionsExt = {
     type: "Pose",
     name: "Pose",
     unit: undefined,
-    icon: () => (
-      <Tooltip disableInteractive title="Pose">
-        <Waypoint></Waypoint>
-      </Tooltip>
-    )
+    icon: () => <Waypoint></Waypoint>
   }
 } as const satisfies {
   [key in DimensionNameExt]: Dimension<key>;

--- a/src/document/ExpressionStore.tsx
+++ b/src/document/ExpressionStore.tsx
@@ -7,7 +7,6 @@ import {
   SyncOutlined,
   TimerOutlined
 } from "@mui/icons-material";
-import { Tooltip } from "@mui/material";
 import {
   AccessorNode,
   ConstantNode,


### PR DESCRIPTION
These are redundant (since the name is right there) and blocked by the menu item click handler. There's also some issues with using function components directly inside Tooltips.