### PR TITLE
Fix fmtJava pnpm script to run on powershell

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "scripts": {
     "fmtCpp": "wpiformat",
-    "fmtJava": "cd choreolib && bash ./gradlew spotlessApply",
+    "fmtJava": "cd choreolib && gradlew spotlessApply",
     "fmtJs": "prettier --write .",
     "fmtRs": "cargo fmt",
     "lintJs": "eslint --fix src",


### PR DESCRIPTION
Tested on Windows Powershell and Windows Git Bash.

Previously `pnpm run fmtJava` called `bash` explicitly, but I found that Gradle handles the relative path to the `gradlew` if it's called like in this PR. Testing on other platforms is welcome.