### PR TITLE
Directly depend on global variables store in expression stores

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -49,7 +49,7 @@ import {
   IWaypointScope
 } from "./ConstraintStore";
 import { EventMarkerStore, IEventMarkerStore } from "./EventMarkerStore";
-import { IExpressionStore, IVariables, Variables } from "./ExpressionStore";
+import { IExpressionStore, IVariables, variables } from "./ExpressionStore";
 import {
   IHolonomicWaypointStore,
   HolonomicWaypointStore as WaypointStore
@@ -215,7 +215,6 @@ function getConstructors(vars: () => IVariables): EnvConstructors {
     }
   };
 }
-const variables = Variables.create({ expressions: {}, poses: {} });
 
 const env = {
   selectedSidebar: () => safeGetIdentifier(doc.selectedSidebarItem),

--- a/src/document/ExpressionStore.tsx
+++ b/src/document/ExpressionStore.tsx
@@ -201,19 +201,13 @@ export const ExpressionStore = types
   .volatile((self) => ({
     tempDisableRecalc: false,
     value: 0,
+    // To avoid circular initialization, we set the correct scope getter in afterCreate
     getScope: () => {
-      // intentionally not typing it here, so that there's not a circular type dependency
-      if (!hasEnv(self)) {
-        tracing.error("Evaluating without environment!", self.toString());
-        return new Map<string, any>();
-      }
-      const env = getEnv(self);
-      if (env.vars === undefined) {
-        tracing.error("Evaluating without variables!", self.toString());
-        return new Map<string, any>();
-      }
-      const scope = env.vars().scope;
-      return scope;
+      tracing.error(
+        "ExpressionStore did not set its scope getter!",
+        self.toString()
+      );
+      return new Map<string, any>();
     }
   }))
   .views((self) => ({

--- a/src/document/ExpressionStore.tsx
+++ b/src/document/ExpressionStore.tsx
@@ -23,7 +23,7 @@ import {
   isUnit
 } from "mathjs";
 import { IReactionDisposer, reaction, untracked } from "mobx";
-import { Instance, detach, getEnv, hasEnv, types } from "mobx-state-tree";
+import { Instance, detach, getEnv, types } from "mobx-state-tree";
 import Angle from "../assets/Angle";
 import Mass from "../assets/Mass";
 import MoI from "../assets/MoI";


### PR DESCRIPTION
I don't like having to do this, but we were already injecting this instance into every ExpressionStore through `Variables.createExpression`. (See former line 590 in ExpressionStore.tsx)

Unfortunately, undoing an operation that deletes an ExpressionStore (through deleting a waypoint, constraint, etc) does not use `createExpression`, so restored ExpressionStores did not get the injection. This worked in most cases because the Variables instance was injected two different ways, but only when the store was created after the Variables instance was created. In short, the existing system is fragile and puts annoying constraints on initialization order just to avoid a direct import as a way to access a global constant. 