### PR TITLE
[trajoptlib] Fix keep-out polygon distance

### DIFF
--- a/trajoptlib/include/trajopt/constraint/LinePointConstraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/LinePointConstraint.hpp
@@ -8,7 +8,7 @@
 #include <sleipnir/autodiff/Variable.hpp>
 #include <sleipnir/optimization/OptimizationProblem.hpp>
 
-#include "trajopt/constraint/detail/LinePointDistance.hpp"
+#include "trajopt/constraint/detail/LinePointSquaredDistance.hpp"
 #include "trajopt/geometry/Pose2.hpp"
 #include "trajopt/geometry/Translation2.hpp"
 #include "trajopt/util/SymbolExports.hpp"
@@ -61,8 +61,9 @@ class TRAJOPT_DLLEXPORT LinePointConstraint {
         pose.Translation() + m_robotLineStart.RotateBy(pose.Rotation());
     auto lineEnd =
         pose.Translation() + m_robotLineEnd.RotateBy(pose.Rotation());
-    auto dist = detail::LinePointDistance(lineStart, lineEnd, m_fieldPoint);
-    problem.SubjectTo(dist * dist >= m_minDistance * m_minDistance);
+    auto squaredDistance =
+        detail::LinePointSquaredDistance(lineStart, lineEnd, m_fieldPoint);
+    problem.SubjectTo(squaredDistance >= m_minDistance * m_minDistance);
   }
 
  private:

--- a/trajoptlib/include/trajopt/constraint/PointLineConstraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/PointLineConstraint.hpp
@@ -8,7 +8,7 @@
 #include <sleipnir/autodiff/Variable.hpp>
 #include <sleipnir/optimization/OptimizationProblem.hpp>
 
-#include "trajopt/constraint/detail/LinePointDistance.hpp"
+#include "trajopt/constraint/detail/LinePointSquaredDistance.hpp"
 #include "trajopt/geometry/Pose2.hpp"
 #include "trajopt/geometry/Translation2.hpp"
 #include "trajopt/util/SymbolExports.hpp"
@@ -58,9 +58,9 @@ class TRAJOPT_DLLEXPORT PointLineConstraint {
              [[maybe_unused]] const Translation2v& linearAcceleration,
              [[maybe_unused]] const sleipnir::Variable& angularAcceleration) {
     auto point = pose.Translation() + m_robotPoint.RotateBy(pose.Rotation());
-    auto dist =
-        detail::LinePointDistance(m_fieldLineStart, m_fieldLineEnd, point);
-    problem.SubjectTo(dist * dist >= m_minDistance * m_minDistance);
+    auto squaredDistance = detail::LinePointSquaredDistance(
+        m_fieldLineStart, m_fieldLineEnd, point);
+    problem.SubjectTo(squaredDistance >= m_minDistance * m_minDistance);
   }
 
  private:

--- a/trajoptlib/include/trajopt/constraint/detail/LinePointSquaredDistance.hpp
+++ b/trajoptlib/include/trajopt/constraint/detail/LinePointSquaredDistance.hpp
@@ -10,9 +10,9 @@ namespace trajopt::detail {
 
 // https://www.desmos.com/calculator/cqmc1tjtsv
 template <typename T, typename U>
-decltype(auto) LinePointDistance(const Translation2<T>& lineStart,
-                                 const Translation2<T>& lineEnd,
-                                 const Translation2<U>& point) {
+decltype(auto) LinePointSquaredDistance(const Translation2<T>& lineStart,
+                                        const Translation2<T>& lineEnd,
+                                        const Translation2<U>& point) {
   using R = decltype(std::declval<T>() + std::declval<U>());
 
   auto max = [](R a, R b) {


### PR DESCRIPTION
LinePointDistance() was returning the squared norm, so squaring it again in the constraint was incorrect.