### PR TITLE
Remove file associations for STL headers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,7 @@
     ],
     "files.associations": {
         "*.py": "python",
-        "*.traj": "json",
-        "vector": "cpp",
-        "array": "cpp",
-        "deque": "cpp",
-        "map": "cpp",
-        "unordered_map": "cpp",
-        "type_traits": "cpp"
+        "*.traj": "json"
     },
-    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.configuration.updateBuildConfiguration": "interactive"
 }


### PR DESCRIPTION
The STL has hundreds of these, which adds a lot of noise.