### PR TITLE
Alert QoL + Docs updates

### DIFF
--- a/choreolib/src/main/java/choreo/util/ChoreoAlert.java
+++ b/choreolib/src/main/java/choreo/util/ChoreoAlert.java
@@ -4,12 +4,25 @@ package choreo.util;
 
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
+import edu.wpi.first.wpilibj.DriverStation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
 /** A utility class for creating alerts under the "ChoreoAlert" group. */
 public class ChoreoAlert {
+  private static boolean firstAlertTriggered = false;
+
+  private static void warnOnFirstTrigger() {
+    if (firstAlertTriggered) {
+      return;
+    }
+    firstAlertTriggered = true;
+    DriverStation.reportWarning(
+        "ChoreoLib has encountered an error: check SmartDashboard/ChoreoAlert for more details.",
+        false);
+  }
+
   /**
    * Creates an alert under the "Choreo" group.
    *
@@ -18,7 +31,13 @@ public class ChoreoAlert {
    * @return an Alert published under the "Choreo" group
    */
   public static Alert alert(String name, AlertType type) {
-    return new Alert("ChoreoAlert", name, type);
+    return new Alert("ChoreoAlert", name, type) {
+      @Override
+      public void set(boolean active) {
+        super.set(active);
+        warnOnFirstTrigger();
+      }
+    };
   }
 
   /**
@@ -56,6 +75,12 @@ public class ChoreoAlert {
       causes.add(name);
       setText(textGenerator.apply(causes));
       set(true);
+    }
+
+    @Override
+    public void set(boolean active) {
+      super.set(active);
+      warnOnFirstTrigger();
     }
   }
 }

--- a/choreolib/src/main/java/choreo/util/ChoreoAlert.java
+++ b/choreolib/src/main/java/choreo/util/ChoreoAlert.java
@@ -4,25 +4,12 @@ package choreo.util;
 
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
-import edu.wpi.first.wpilibj.DriverStation;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
 /** A utility class for creating alerts under the "ChoreoAlert" group. */
 public class ChoreoAlert {
-  private static boolean firstAlertTriggered = false;
-
-  private static void warnOnFirstTrigger() {
-    if (firstAlertTriggered) {
-      return;
-    }
-    firstAlertTriggered = true;
-    DriverStation.reportWarning(
-        "ChoreoLib has encountered an error: check SmartDashboard/ChoreoAlert for more details.",
-        false);
-  }
-
   /**
    * Creates an alert under the "Choreo" group.
    *
@@ -31,13 +18,7 @@ public class ChoreoAlert {
    * @return an Alert published under the "Choreo" group
    */
   public static Alert alert(String name, AlertType type) {
-    return new Alert("ChoreoAlert", name, type) {
-      @Override
-      public void set(boolean active) {
-        super.set(active);
-        warnOnFirstTrigger();
-      }
-    };
+    return new Alert("ChoreoAlert", name, type);
   }
 
   /**
@@ -75,12 +56,6 @@ public class ChoreoAlert {
       causes.add(name);
       setText(textGenerator.apply(causes));
       set(true);
-    }
-
-    @Override
-    public void set(boolean active) {
-      super.set(active);
-      warnOnFirstTrigger();
     }
   }
 }

--- a/docs/choreolib/getting-started.md
+++ b/docs/choreolib/getting-started.md
@@ -264,10 +264,10 @@ In general, trajectory followers accept trajectory "samples" that represent the 
         1. For more information about differential drive kinematics, see [WPILib's documentation](https://docs.wpilib.org/en/stable/docs/software/kinematics-and-odometry/differential-drive-kinematics.html). In this example, we assume you have created an instance of `DifferentialDriveKinematics`, named `kinematics`.
 
 ## Choreo-Specific Alerts
-Choreo primarily uses WPILib's Alerts api to warn users of error(or warning) conditions. These alerts
+Choreo primarily uses the WPILib Alerts API to provide users with internal warnings, errors or information. These alerts
 can be found under the SmartDashboard/ChoreoAlert section within networktables. 
 
-To visualize these alerts on a dashboard or advantagescope, simply drag the ChoreoAlert group 
+To visualize these alerts in a dashboard such as AdvantageScope simply drag the ChoreoAlert group 
 outwards onto the "discrete fields" section in advantagescope or the main dashboard panel. 
 
 ## Next Steps

--- a/docs/choreolib/getting-started.md
+++ b/docs/choreolib/getting-started.md
@@ -263,6 +263,13 @@ In general, trajectory followers accept trajectory "samples" that represent the 
 
         1. For more information about differential drive kinematics, see [WPILib's documentation](https://docs.wpilib.org/en/stable/docs/software/kinematics-and-odometry/differential-drive-kinematics.html). In this example, we assume you have created an instance of `DifferentialDriveKinematics`, named `kinematics`.
 
+## Choreo-Specific Alerts
+Choreo primarily uses WPILib's Alerts api to warn users of error(or warning) conditions. These alerts
+can be found under the SmartDashboard/ChoreoAlert section within networktables. 
+
+To visualize these alerts on a dashboard or advantagescope, simply drag the ChoreoAlert group 
+outwards onto the "discrete fields" section in advantagescope or the main dashboard panel. 
+
 ## Next Steps
 
 <div class="grid cards" markdown>

--- a/docs/choreolib/getting-started.md
+++ b/docs/choreolib/getting-started.md
@@ -265,10 +265,10 @@ In general, trajectory followers accept trajectory "samples" that represent the 
 
 ## Choreo-Specific Alerts
 Choreo primarily uses the WPILib Alerts API to provide users with internal warnings, errors or information. These alerts
-can be found under the SmartDashboard/ChoreoAlert section within networktables. 
+can be found under the SmartDashboard/ChoreoAlert section within networktables.
 
-To visualize these alerts in a dashboard such as AdvantageScope simply drag the ChoreoAlert group 
-outwards onto the "discrete fields" section in advantagescope or the main dashboard panel. 
+To visualize these alerts in a dashboard such as AdvantageScope simply drag the ChoreoAlert group
+outwards onto the "discrete fields" section in advantagescope or the main dashboard panel.
 
 ## Next Steps
 

--- a/docs/choreolib/getting-started.md
+++ b/docs/choreolib/getting-started.md
@@ -264,11 +264,9 @@ In general, trajectory followers accept trajectory "samples" that represent the 
         1. For more information about differential drive kinematics, see [WPILib's documentation](https://docs.wpilib.org/en/stable/docs/software/kinematics-and-odometry/differential-drive-kinematics.html). In this example, we assume you have created an instance of `DifferentialDriveKinematics`, named `kinematics`.
 
 ## Choreo-Specific Alerts
-Choreo primarily uses the WPILib Alerts API to provide users with internal warnings, errors or information. These alerts
-can be found under the SmartDashboard/ChoreoAlert section within networktables.
+Choreo primarily uses the WPILib Alerts API to provide users with internal warnings, errors or information. These alerts can be found under the SmartDashboard/ChoreoAlert section within networktables.
 
-To visualize these alerts in a dashboard such as AdvantageScope simply drag the ChoreoAlert group
-outwards onto the "discrete fields" section in advantagescope or the main dashboard panel.
+To visualize these alerts in a dashboard such as AdvantageScope simply drag the ChoreoAlert group outwards onto the "discrete fields" section in advantagescope or the main dashboard panel.
 
 ## Next Steps
 


### PR DESCRIPTION
Docs have been updated to show that ChoreoAlerts exist(pretty important to get out before first complete release).

In addition, ChoreoAlert now runs a singular DriverStation.reportWarning the first time any alert gets triggered; acting as a reminder for people to check the alerts section if they do not have it up. It only prints once, so its designed for people who are still used to checking the console for errors.