### PR TITLE
[trajoptlib] Set dt upper bound

### DIFF
--- a/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
+++ b/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
@@ -152,6 +152,8 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
     T_tot += T_sgmt;
 
     problem.SubjectTo(dt >= 0);
+    problem.SubjectTo(dt <= 0.075);
+
     // Use initialGuess and Ns to find the dx, dy, dθ between wpts
     const auto sgmt_start = GetIndex(Ns, sgmtIndex);
     const auto sgmt_end = GetIndex(Ns, sgmtIndex + 1);

--- a/trajoptlib/src/SwerveTrajectoryGenerator.cpp
+++ b/trajoptlib/src/SwerveTrajectoryGenerator.cpp
@@ -125,6 +125,7 @@ SwerveTrajectoryGenerator::SwerveTrajectoryGenerator(
     T_tot += T_sgmt;
 
     problem.SubjectTo(dt >= 0);
+    problem.SubjectTo(dt <= 0.075);
 
     // Use initialGuess and Ns to find the dx, dy, dθ between wpts
     const auto sgmt_start = GetIndex(Ns, sgmtIndex);


### PR DESCRIPTION
Without it, the solver increases dt a lot, then reports infeasible on most paths.

The anti-tunneling constraint implicitly set an upper bound on dt, but setting an explicit upper bound is better.