### PR TITLE
Clear path list when opening a new project

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -690,6 +690,7 @@ export async function newProject() {
   const newChor = await Commands.defaultProject();
   doc.deserializeChor(newChor);
   uiState.loadPathGradientFromLocalStorage();
+  doc.pathlist.deleteAll();
   doc.pathlist.addPath("New Path");
   doc.history.clear();
 }


### PR DESCRIPTION
Missed this when adding `deleteAll()`