### PR TITLE
Avoid using environment when deserializing commands before tree attachment

### DIFF
--- a/src/document/CommandStore.tsx
+++ b/src/document/CommandStore.tsx
@@ -14,7 +14,7 @@ import {
   NamedCommand,
   WaitCommand
 } from "./2025/DocumentTypes";
-import { Env } from "./DocumentManager";
+import { Env, EnvConstructors } from "./DocumentManager";
 import { ExpressionStore } from "./ExpressionStore";
 
 export type CommandGroupType = "sequential" | "parallel" | "deadline" | "race";
@@ -109,7 +109,7 @@ export const CommandStore = types
     }
   }))
   .actions((self) => ({
-    deserialize(ser: Command) {
+    deserialize(ser: Command, constructor: EnvConstructors["CommandStore"]) {
       self.commands.clear();
       self.name = "";
       if (ser === undefined || ser === null) {
@@ -123,9 +123,8 @@ export const CommandStore = types
         self.time.deserialize(ser.data.waitTime);
       } else {
         ser.data.commands.forEach((c) => {
-          const command: ICommandStore =
-            getEnv<Env>(self).create.CommandStore(c);
-          command.deserialize(c);
+          const command: ICommandStore = constructor(c);
+          command.deserialize(c, constructor);
           self.commands.push(command);
         });
       }

--- a/src/document/EventMarkerStore.tsx
+++ b/src/document/EventMarkerStore.tsx
@@ -6,7 +6,7 @@ import {
 } from "./2025/DocumentTypes";
 import { CommandStore } from "./CommandStore";
 import { WaypointScope } from "./ConstraintStore";
-import { Env } from "./DocumentManager";
+import { Env, EnvConstructors } from "./DocumentManager";
 import { ExpressionStore } from "./ExpressionStore";
 import { IChoreoTrajectoryStore } from "./path/ChoreoTrajectoryStore";
 import { IHolonomicPathStore } from "./path/HolonomicPathStore";
@@ -145,10 +145,13 @@ export const EventMarkerStore = types
     setName(name: string) {
       self.name = name;
     },
-    deserialize(ser: EventMarker) {
+    deserialize(
+      ser: EventMarker,
+      commandConstructor: EnvConstructors["CommandStore"]
+    ) {
       self.name = ser.name;
       self.from.deserialize(ser.from);
-      self.event.deserialize(ser.event);
+      self.event.deserialize(ser.event, commandConstructor);
     },
     setSelected(selected: boolean) {
       if (selected && !self.selected) {

--- a/src/document/path/HolonomicPathStore.ts
+++ b/src/document/path/HolonomicPathStore.ts
@@ -115,7 +115,7 @@ export const HolonomicPathStore = types
         const toAdd = getEnv<Env>(self).create.EventMarkerStore(m);
 
         self.markers.push(toAdd);
-        toAdd.deserialize(m);
+        toAdd.deserialize(m, getEnv<Env>(self).create.CommandStore);
         return toAdd;
       },
       setSnapshot(snap: ChoreoPath<number>) {


### PR DESCRIPTION
Because we deserialize the command payload recursively, it's not in the main document tree at that time, so we can't use mobx environment injection to access the CommandStore constructor.

Prior bug: Try to load a project with an event marker which has at least one command payload (i.e. not "None). Loading fails with a browser console warning about "Cannot get environment for CommandStore".

