### PR TITLE
[choreolib] Fix JDK 21 Javadoc errors

### DIFF
--- a/choreolib/src/main/java/choreo/util/ChoreoAlert.java
+++ b/choreolib/src/main/java/choreo/util/ChoreoAlert.java
@@ -58,4 +58,7 @@ public class ChoreoAlert {
       set(true);
     }
   }
+
+  /** Factory class. */
+  private ChoreoAlert() {}
 }

--- a/choreolib/src/main/java/choreo/util/ChoreoArrayUtil.java
+++ b/choreolib/src/main/java/choreo/util/ChoreoArrayUtil.java
@@ -43,4 +43,7 @@ public class ChoreoArrayUtil {
     }
     return true;
   }
+
+  /** Factory class. */
+  private ChoreoArrayUtil() {}
 }


### PR DESCRIPTION
Javadoc 21 complains about undocumented default constructors.