### PR TITLE
[ui] Update staleness indicator when deserializing paths

### DIFF
--- a/src/document/path/HolonomicPathStore.ts
+++ b/src/document/path/HolonomicPathStore.ts
@@ -173,6 +173,9 @@ export const HolonomicPathStore = types
         ser.events.forEach((m) => {
           self.addEventMarker(m);
         });
+        Commands.trajectoryUpToDate(self.serialize).then((upToDate) =>
+          self.ui.setUpToDate(upToDate)
+        );
       }
     };
   })


### PR DESCRIPTION
This is an explicit update because updating on changes to the serialization doesn't catch all paths when first opening the project.