### PR TITLE
Expressions referencing missing variables now evaluate to undefined.

### DIFF
--- a/src/document/ExpressionStore.tsx
+++ b/src/document/ExpressionStore.tsx
@@ -260,40 +260,41 @@ export const ExpressionStore = types
     }
   }))
   .views((self) => ({
-    evaluator(node: MathNode): MathType {
-      // TODO investigate whether this should be untracked
-      const scope: Map<string, any> =
-        self.getScope() ??
-        ((() => {
-          tracing.error("Evaluating without variables!");
-          return undefined;
-        }) as Evaluator);
-      // Depend on the keys list of the scope, to re-evaluate when the variables list changes
-      scope.keys();
-      // turn symbol variables into function variables if they're found in scope
-      const transformed = node.transform((innerNode, path, parent) => {
-        // Match standalone symbols, turn them into FunctionNode(symbol)
-        if (
-          isSymbolNode(innerNode) && // Match symbols (string literals in the expression),
-          //that are names of functions in our scope (just the standalone variables)
-          typeof scope.get(innerNode.name) === "function" &&
-          // The below avoids transforming `variable()` to `variable()()`
-          !(
-            // ...and ignoring those symbol nodes
-            (
-              parent !== null && // with a non-null parent
-              isFunctionNode(parent) && // that is a function node
-              path == "fn"
-            ) // where the symbol is already the name of the function
-          )
-        ) {
-          return new math.FunctionNode(innerNode, []);
-        }
+    evaluator(node: MathNode): MathType | undefined {
+      try {
+        // TODO investigate whether this should be untracked
+        const scope: Map<string, any> =
+          self.getScope() ??
+          ((() => {
+            tracing.error("Evaluating without variables!");
+            return undefined;
+          }) as Evaluator);
+        // Depend on the keys list of the scope, to re-evaluate when the variables list changes
+        scope.keys();
+        // turn symbol variables into function variables if they're found in scope
+        const transformed = node.transform((innerNode, path, parent) => {
+          // Match standalone symbols, turn them into FunctionNode(symbol)
+          if (
+            isSymbolNode(innerNode) && // Match symbols (string literals in the expression),
+            //that are names of functions in our scope (just the standalone variables)
+            typeof scope.get(innerNode.name) === "function" &&
+            // The below avoids transforming `variable()` to `variable()()`
+            !(
+              // ...and ignoring those symbol nodes
+              (
+                parent !== null && // with a non-null parent
+                isFunctionNode(parent) && // that is a function node
+                path == "fn"
+              ) // where the symbol is already the name of the function
+            )
+          ) {
+            return new math.FunctionNode(innerNode, []);
+          }
 
-        // Replace [pose].x (and .y, .heading) with [pose].x(), etc
-        // This works for other objects in scope with children that are functions
+          // Replace [pose].x (and .y, .heading) with [pose].x(), etc
+          // This works for other objects in scope with children that are functions
 
-        /*
+          /*
           Replace [pose].x (and .y, .heading) with [pose].x(), etc
           This works for other objects in scope with children that are functions
           "[objectName].[childName]" parses to
@@ -318,36 +319,40 @@ export const ExpressionStore = types
             So if we match [objectName].[childName], but it's already within a function node, don't transform it
           */
 
-        if (isAccessorNode(innerNode)) {
-          // filter out accessors within function nodes.
-          if (!(parent !== null && isFunctionNode(parent) && path == "fn")) {
-            const accessorNode = innerNode;
-            const { object, index } = accessorNode;
-            if (isSymbolNode(object) && index.isIndexNode) {
-              const symbol = object as SymbolNode;
-              const idx = index as IndexNode;
-              if (
-                idx.dimensions[0] !== undefined &&
-                isConstantNode(idx.dimensions[0])
-              ) {
-                const constant = idx.dimensions[0];
-                // We now know that innerNode was [symbol.name].[constant.value]
+          if (isAccessorNode(innerNode)) {
+            // filter out accessors within function nodes.
+            if (!(parent !== null && isFunctionNode(parent) && path == "fn")) {
+              const accessorNode = innerNode;
+              const { object, index } = accessorNode;
+              if (isSymbolNode(object) && index.isIndexNode) {
+                const symbol = object as SymbolNode;
+                const idx = index as IndexNode;
                 if (
-                  typeof scope.get(symbol.name) === "object" &&
-                  typeof scope.get(symbol.name)?.[constant.value] === "function"
+                  idx.dimensions[0] !== undefined &&
+                  isConstantNode(idx.dimensions[0])
                 ) {
-                  // if the symbols are in fact things in our scope, replace `innerNode` with `innerNode()`
-                  return new FunctionNode(innerNode, []);
+                  const constant = idx.dimensions[0];
+                  // We now know that innerNode was [symbol.name].[constant.value]
+                  if (
+                    typeof scope.get(symbol.name) === "object" &&
+                    typeof scope.get(symbol.name)?.[constant.value] ===
+                      "function"
+                  ) {
+                    // if the symbols are in fact things in our scope, replace `innerNode` with `innerNode()`
+                    return new FunctionNode(innerNode, []);
+                  }
                 }
               }
             }
           }
-        }
-        return innerNode;
-      });
-      const result = transformed.evaluate(scope) ?? undefined;
+          return innerNode;
+        });
+        const result = transformed.evaluate(scope) ?? undefined;
 
-      return result;
+        return result;
+      } catch {
+        return undefined;
+      }
     },
     get serialize(): Expr {
       return {
@@ -357,21 +362,24 @@ export const ExpressionStore = types
     }
   }))
   .views((self) => ({
-    get evaluate(): MathType {
+    get evaluate(): MathType | undefined {
       const result = self.evaluator(self.expr);
       return result;
     }
   }))
   .views((self) => ({
-    get asScope() {
+    get asScope(): () => MathType | undefined {
       return () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         self.value;
-
-        const expr = untracked(() => {
-          return self.evaluate;
-        });
-        return expr;
+        try {
+          const expr = untracked(() => {
+            return self.evaluate;
+          });
+          return expr;
+        } catch {
+          return undefined;
+        }
       };
     },
     get toDefaultUnit(): Unit | number | undefined {
@@ -415,7 +423,7 @@ export const ExpressionStore = types
     },
     validate(newNode: MathNode): MathNode | undefined {
       // number | BigNumber | bigint | Fraction | Complex | Unit
-      let newNumber: MathType;
+      let newNumber: MathType | undefined | null;
       try {
         newNumber = self.evaluator(newNode);
       } catch (e) {


### PR DESCRIPTION
We already expected `math.evaluate()` to return undefined in some cases. Previously we did try-catch blocks on `validate`, but this did not help when evaluating the variables which relied on other variables. Accessing a missing variable throws an exception in `math.evaluate()`.

Previously:
If you made a `variable2` referencing a `variable1`, even if the `variable2` wasn't referenced in any paths, deleting `variable1` would cause the app UI to white-out crash. This is because deleting or adding variables triggers re-evaluation on all expressions. `variable2` is re-evaluated and its value substituted into the scope. That re-evaluation had no try-catch, so the app crashed.

New behavior:
Upon deleting a variable, all direct (as previous) and transitive (new behavior) dependencies of that variable should appear invalid (red line).