### PR TITLE
Move pose variable panel dropdown to right side to clarify purpose

### DIFF
--- a/src/components/config/variables/PoseVariablesConfigPanel.tsx
+++ b/src/components/config/variables/PoseVariablesConfigPanel.tsx
@@ -40,7 +40,7 @@ const PoseVariablePanel = observer(
           style={{
             display: "flex",
             flexDirection: "row",
-            justifyContent: "space-between",
+            justifyContent: "space-between"
           }}
           onClick={() => {
             if (props.setOpen !== undefined) {

--- a/src/components/config/variables/PoseVariablesConfigPanel.tsx
+++ b/src/components/config/variables/PoseVariablesConfigPanel.tsx
@@ -16,7 +16,12 @@ type PoseVariablePanelProps = {
 };
 
 const PoseVariablePanel = observer(
-  (props: PoseVariablePanelProps & { open: boolean }) => {
+  (
+    props: PoseVariablePanelProps & {
+      open: boolean;
+      setOpen: undefined | ((open: boolean) => void);
+    }
+  ) => {
     const entry = props.entry;
 
     return (
@@ -30,7 +35,35 @@ const PoseVariablePanel = observer(
           setName={(name) => props.setName(name)}
           validateName={(name) => props.validateName(name)}
         ></VariableRenamingInput>
-        {`(${entry[1].x.defaultUnitMagnitude?.toFixed(2)} m, ${entry[1].y.defaultUnitMagnitude?.toFixed(2)} m, ${entry[1].heading.defaultUnitMagnitude?.toFixed(2)} rad)`}
+        {/* The part that stays visible when closed. Clicking it opens/closes the panel if setOpen is defined*/}
+        <span
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "space-between",
+          }}
+          onClick={() => {
+            if (props.setOpen !== undefined) {
+              props.setOpen(!props.open);
+            }
+          }}
+        >
+          <span>
+            {`(${entry[1].x.value.toFixed(2)} m, ${entry[1].y.value.toFixed(2)} m, ${entry[1].heading.value.toFixed(2)} rad)`}
+          </span>
+          <Tooltip
+            disableInteractive
+            title={!props.open ? "Edit Pose" : "Close Panel"}
+          >
+            <span>
+              {props.open && props.setOpen !== undefined ? (
+                <ArrowDropUp></ArrowDropUp>
+              ) : (
+                <ArrowDropDown></ArrowDropDown>
+              )}
+            </span>
+          </Tooltip>
+        </span>
         {props.actionButton()}
         {props.open && (
           <>
@@ -75,17 +108,13 @@ const OpenablePoseVariablePanel = observer(
     return (
       <PoseVariablePanel
         open={open}
+        setOpen={setOpen}
         {...props}
         logo={() => (
           <span>
             <Tooltip disableInteractive title={DimensionsExt["Pose"].name}>
               {DimensionsExt["Pose"].icon()}
-            </Tooltip>{" "}
-            {open ? (
-              <ArrowDropUp onClick={() => setOpen(false)}></ArrowDropUp>
-            ) : (
-              <ArrowDropDown onClick={() => setOpen(true)}></ArrowDropDown>
-            )}
+            </Tooltip>
           </span>
         )}
       ></PoseVariablePanel>
@@ -105,6 +134,7 @@ export const AddPoseVariablePanel = observer(
         validateName={(name) => doc.variables.validateName(name, "")}
         logo={props.logo}
         open={true}
+        setOpen={undefined}
         entry={[props.name, props.pose]}
         setName={(name) => props.setName(name)}
         actionButton={() => (


### PR DESCRIPTION
Also, clicking on the (XXX m, XXX m, XXX rad) part also works as a dropdown button.
Also fixes that preview to use the `value` (last successful evaluation, which is what nearly everything else in the app uses), instead of re-evaluating and potentially getting `undefined`.