### PR TITLE
[trajoptlib] [choreolib] Fix bugs preventing 0 samples between waypoints

### DIFF
--- a/choreolib/src/main/java/choreo/trajectory/Trajectory.java
+++ b/choreolib/src/main/java/choreo/trajectory/Trajectory.java
@@ -239,13 +239,15 @@ public class Trajectory<SampleType extends TrajectorySample<SampleType>> {
    * @return a choreo trajectory that represents the split of the trajectory at the given index.
    */
   public Optional<Trajectory<SampleType>> getSplit(int splitIndex) {
+    // Assumption: splits.get(splitIndex) is a valid index of samples.
     if (splitIndex < 0 || splitIndex >= splits.size()) {
       return Optional.empty();
     }
     int start = splits.get(splitIndex);
     int end = splitIndex + 1 < splits.size() ? splits.get(splitIndex + 1) + 1 : samples.size();
     var sublist = samples.subList(start, end);
-    // Empty section can be achieved by two identical waypoints in sequence
+    // Empty section should not be achievable (would mean malformed splits array), but is handled
+    // for safety
     if (sublist.size() == 0) {
       return Optional.of(
           new Trajectory<SampleType>(

--- a/choreolib/src/main/java/choreo/trajectory/Trajectory.java
+++ b/choreolib/src/main/java/choreo/trajectory/Trajectory.java
@@ -245,6 +245,13 @@ public class Trajectory<SampleType extends TrajectorySample<SampleType>> {
     int start = splits.get(splitIndex);
     int end = splitIndex + 1 < splits.size() ? splits.get(splitIndex + 1) + 1 : samples.size();
     var sublist = samples.subList(start, end);
+    // Empty section can be achieved by two identical waypoints in sequence
+    if (sublist.size() == 0) {
+      return Optional.of(
+          new Trajectory<SampleType>(
+              this.name + "[" + splitIndex + "]", List.of(), List.of(), List.of()));
+    }
+    // Now we know sublist.size() >= 1
     double startTime = sublist.get(0).getTimestamp();
     double endTime = sublist.get(sublist.size() - 1).getTimestamp();
     return Optional.of(

--- a/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
@@ -215,6 +215,7 @@ class Trajectory {
    * the given index.
    */
   std::optional<Trajectory<SampleType>> GetSplit(int splitIndex) const {
+    // Assumption: splits[splitIndex] is a valid index of samples.
     if (splitIndex < 0 || splitIndex >= splits.size()) {
       return std::nullopt;
     }
@@ -225,7 +226,8 @@ class Trajectory {
 
     auto sublist =
         std::vector<SampleType>(samples.begin() + start, samples.begin() + end);
-    // Empty section can be achieved by two identical waypoints in sequence
+    // Empty section should not be achievable (would mean malformed splits
+    // array), but is handled for safety
     if (sublist.size() == 0) {
       return Trajectory<SampleType>{
           name + "[" + std::to_string(splitIndex) + "]", {}, {}, {}};

--- a/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
@@ -225,6 +225,12 @@ class Trajectory {
 
     auto sublist =
         std::vector<SampleType>(samples.begin() + start, samples.begin() + end);
+    // Empty section can be achieved by two identical waypoints in sequence
+    if (sublist.size() == 0) {
+      return Trajectory<SampleType>{
+          name + "[" + std::to_string(splitIndex) + "]", {}, {}, {}};
+    }
+    // Now we know sublist.size() >= 1
     units::second_t startTime = sublist.front().GetTimestamp();
     units::second_t endTime = sublist.back().GetTimestamp();
 

--- a/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
+++ b/trajoptlib/src/DifferentialTrajectoryGenerator.cpp
@@ -155,28 +155,33 @@ DifferentialTrajectoryGenerator::DifferentialTrajectoryGenerator(
     problem.SubjectTo(dt * path.drivetrain.wheelRadius *
                           path.drivetrain.wheelMaxAngularVelocity <=
                       path.drivetrain.trackwidth);
+    if (N_sgmt == 0) {
+      dt.SetValue(0);
+    } else {
+      // Use initialGuess and Ns to find the dx, dy, dθ between wpts
+      const auto sgmt_start = GetIndex(Ns, sgmtIndex);
+      const auto sgmt_end = GetIndex(Ns, sgmtIndex + 1);
+      const auto dx =
+          initialGuess.x.at(sgmt_end) - initialGuess.x.at(sgmt_start);
+      const auto dy =
+          initialGuess.y.at(sgmt_end) - initialGuess.y.at(sgmt_start);
+      const auto dist = std::hypot(dx, dy);
+      const auto θ_0 = initialGuess.heading.at(sgmt_start);
+      const auto θ_1 = initialGuess.heading.at(sgmt_end);
+      const auto dθ = std::abs(AngleModulus(θ_1 - θ_0));
 
-    // Use initialGuess and Ns to find the dx, dy, dθ between wpts
-    const auto sgmt_start = GetIndex(Ns, sgmtIndex);
-    const auto sgmt_end = GetIndex(Ns, sgmtIndex + 1);
-    const auto dx = initialGuess.x.at(sgmt_end) - initialGuess.x.at(sgmt_start);
-    const auto dy = initialGuess.y.at(sgmt_end) - initialGuess.y.at(sgmt_start);
-    const auto dist = std::hypot(dx, dy);
-    const auto θ_0 = initialGuess.heading.at(sgmt_start);
-    const auto θ_1 = initialGuess.heading.at(sgmt_end);
-    const auto dθ = std::abs(AngleModulus(θ_1 - θ_0));
+      auto maxLinearVel = maxDrivetrainVelocity;
 
-    auto maxLinearVel = maxDrivetrainVelocity;
+      const auto angularTime =
+          CalculateTrapezoidalTime(dθ, maxAngVel, maxAngAccel);
+      maxLinearVel = std::min(maxLinearVel, dist / angularTime);
 
-    const auto angularTime =
-        CalculateTrapezoidalTime(dθ, maxAngVel, maxAngAccel);
-    maxLinearVel = std::min(maxLinearVel, dist / angularTime);
+      const auto linearTime =
+          CalculateTrapezoidalTime(dist, maxLinearVel, maxAccel);
+      const double sgmtTime = angularTime + linearTime;
 
-    const auto linearTime =
-        CalculateTrapezoidalTime(dist, maxLinearVel, maxAccel);
-    const double sgmtTime = angularTime + linearTime;
-
-    dt.SetValue(sgmtTime / N_sgmt);
+      dt.SetValue(sgmtTime / N_sgmt);
+    }
   }
   problem.Minimize(std::move(T_tot));
 


### PR DESCRIPTION
This can happen with two identical adjacent waypoints, where the heuristic determines there is 0 time between them. This should be acceptable, because the two waypoints often do not have incompatible constraints. However, averaging segment time over the `0` samples in the segment led to NaNs and a "nonfinite cost or constraints" (actually nonfinite decision variable) solver error.

Accompanying ChoreoLib changes handle a split trajectory with no samples, which was mistakenly thought to become possible with this change. The code is left in for safety's sake, since the case was not already handled.