### PR TITLE
[trajoptlib] Use LLVM sanitizers

### DIFF
--- a/.github/workflows/trajoptlib-sanitizers.yml
+++ b/.github/workflows/trajoptlib-sanitizers.yml
@@ -32,10 +32,16 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
-      - name: Make GCC 14 the default toolchain (Linux)
+      - name: Install LLVM 19
         run: |
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 200
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 200
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19 all
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 200
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 200
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.5


### PR DESCRIPTION
They're generally more reliable than GCC's.