### PR TITLE
Fixup CLI modifying trajectory parameters

### DIFF
--- a/src-core/src/generation/generate.rs
+++ b/src-core/src/generation/generate.rs
@@ -115,6 +115,9 @@ pub fn generate(
     mut trajectory_file: TrajectoryFile,
     handle: i64,
 ) -> ChoreoResult<TrajectoryFile> {
+    let mut original = trajectory_file.clone();
+
+    // these two functions can make changes to the trajectory file
     set_initial_guess(&mut trajectory_file);
     adjust_headings(&mut trajectory_file)?;
 
@@ -125,5 +128,11 @@ pub fn generate(
     gen.add_omni_transformer::<ConstraintSetter>();
     gen.add_omni_transformer::<CallbackSetter>();
 
-    gen.generate()
+    let new_traj = gen.generate();
+    if new_traj.is_ok() {
+        original.trajectory = new_traj?.trajectory;
+        Ok(original)
+    } else {
+        new_traj
+    }
 }


### PR DESCRIPTION
Fixes: #1197
Fixes: #1049

I tried to take the relevant parts from the [mega PR](https://github.com/SleipnirGroup/Choreo/pull/1070/files?diff=split&w=1#diff-0c1099e790aac17257467ee24a431097c49275ce79a8871a506f73cd463e1737R72-R88) that said it should fix the CLI problems.

I am not super well versed in Rust, so there might be a more rust-ic way to do the Result thing.

I tested this by running the `2025.0.3` gui on our paths last year and this year, making a commit, and then running `choreo-cli.exe --chor <file path> --generate --all-trajectory` and verifying there were no changes. Our paths aren't complicated, basically just stop points and max velocity constraints, but it works for those and doesn't break any tests.

If something does break from this, I would say [If you like it then you should have put a test on it](https://abseil.io/resources/swe-book/html/ch11.html#the_beyonceacutesemicolon_rule)