### PR TITLE
Fix redundant guard warning from clippy

### DIFF
--- a/src-core/src/generation/heading.rs
+++ b/src-core/src/generation/heading.rs
@@ -43,7 +43,7 @@ pub fn calculate_adjusted_headings(trajectory: &TrajectoryFile) -> ChoreoResult<
         let from = constraint.from;
         let to_opt = constraint.to;
         match constraint.data {
-            MaxAngularVelocity { max } if max == 0.0 => {
+            MaxAngularVelocity { max: 0.0 } => {
                 if let Some(to) = to_opt {
                     wpt_has_0_ang_vel[from..=to]
                         .iter_mut()


### PR DESCRIPTION
```
[tav@myriad Choreo]$ cargo clippy
    Checking choreo-core v2025.0.3 (/home/tav/git/Choreo/src-core)
error: redundant guard
  --> src-core/src/generation/heading.rs:46:43
   |
46 |             MaxAngularVelocity { max } if max == 0.0 => {
   |                                           ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards
note: the lint level is defined here
  --> src-core/src/lib.rs:7:9
   |
7  | #![deny(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[deny(clippy::redundant_guards)]` implied by `#[deny(clippy::all)]`
help: try
   |
46 -             MaxAngularVelocity { max } if max == 0.0 => {
46 +             MaxAngularVelocity { max: 0.0 } => {
   |

error: could not compile `choreo-core` (lib) due to 1 previous error
```