### PR TITLE
Fix clippy warnings

### DIFF
--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -198,9 +198,9 @@ fn fill_string(left_aligned: bool, width: usize, mut s: String) -> String {
         return s;
     }
     if left_aligned {
-        s.extend(std::iter::repeat(' ').take(width - s.len()));
+        s.extend(std::iter::repeat_n(' ', width - s.len()));
     } else {
-        let spaces = std::iter::repeat(' ').take(width - s.len());
+        let spaces = std::iter::repeat_n(' ', width - s.len());
         s.insert_str(0, &spaces.collect::<String>());
     }
     s


### PR DESCRIPTION
```
 error: this `repeat().take()` can be written more concisely
   --> src-tauri/src/logging.rs:201:18
    |
201 |         s.extend(std::iter::repeat(' ').take(width - s.len()));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(' ', width - s.len())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n
    = note: `-D clippy::manual-repeat-n` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_repeat_n)]`

error: this `repeat().take()` can be written more concisely
   --> src-tauri/src/logging.rs:203:22
    |
203 |         let spaces = std::iter::repeat(' ').take(width - s.len());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `repeat_n()` instead: `std::iter::repeat_n(' ', width - s.len())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_repeat_n
```