### PR TITLE
[ci] Upgrade sccache action

### DIFF
--- a/.github/workflows/choreo.yml
+++ b/.github/workflows/choreo.yml
@@ -91,7 +91,7 @@ jobs:
         if: startsWith(matrix.os, 'macOS')
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cargo test
         run: cargo test
       - name: Build package

--- a/.github/workflows/trajoptlib-cpp.yml
+++ b/.github/workflows/trajoptlib-cpp.yml
@@ -57,7 +57,7 @@ jobs:
         if: startsWith(matrix.os, 'macOS')
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
         # sccache doesn't work with MSBuild
         if: ${{ !startsWith(matrix.os, 'windows') }}
 

--- a/.github/workflows/trajoptlib-rust.yml
+++ b/.github/workflows/trajoptlib-rust.yml
@@ -53,7 +53,7 @@ jobs:
         if: startsWith(matrix.os, 'macOS')
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
         # sccache doesn't work with MSBuild
         if: ${{ !startsWith(matrix.os, 'windows') }}
 

--- a/.github/workflows/trajoptlib-sanitizers.yml
+++ b/.github/workflows/trajoptlib-sanitizers.yml
@@ -44,7 +44,7 @@ jobs:
           echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.8
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - run: cmake --preset with-examples-and-sccache ${{ matrix.cmake-args }}
         working-directory: trajoptlib


### PR DESCRIPTION
Apparently you need 0.0.9 to utilize the new GHA caching endpoints.