### PR TITLE
Remove libgit2 dependency from build info gathering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
 dependencies = [
  "chrono",
- "git2",
 ]
 
 [[package]]
@@ -413,8 +412,6 @@ version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1515,19 +1512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,15 +2092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,18 +2184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,18 +2211,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -4935,12 +4886,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Sleipnir Group"]
 license = "BSD-3-Clause"
 
 [build-dependencies]
-built = { version = "0.7.5", features = ["chrono", "git2"] }
+built = { version = "0.7.5", features = ["chrono"] }
 tauri-build = { version = "2.0.6", features = [] }
 
 [dependencies]

--- a/src-tauri/src/built.rs
+++ b/src-tauri/src/built.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display, Formatter};
+use std::process::Command;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,7 +25,7 @@ pub struct BuildInfo {
     pub os_family: &'static str,
     pub os: &'static str,
     pub build_time: &'static str,
-    pub git_hash: Option<&'static str>,
+    pub git_hash: Option<String>,
     pub git_branch: Option<String>,
 }
 
@@ -45,7 +46,7 @@ impl Display for BuildInfo {
                 "not "
             }
         )?;
-        if let Some(git_hash) = self.git_hash {
+        if let Some(git_hash) = &self.git_hash {
             writeln!(
                 f,
                 "  from commit {} on branch {}",
@@ -86,9 +87,33 @@ impl BuildInfo {
             os_family: built_info::CFG_FAMILY,
             os: built_info::CFG_OS,
             build_time: built_info::BUILT_TIME_UTC,
-            git_hash: built_info::GIT_COMMIT_HASH_SHORT,
-            git_branch: built_info::GIT_HEAD_REF
-                .map(|s| s.trim_start_matches("refs/heads/").to_string()),
+            // Retrieve git info manually because built's git2 feature uses
+            // libgit2-sys, which takes up to 2 minutes to compile in Windows CI
+            git_hash: Command::new("git")
+                .arg("rev-parse")
+                .arg("--short")
+                .arg("HEAD")
+                .output()
+                .map(|output| {
+                    String::from_utf8(output.stdout)
+                        .expect("invalid UTF-8 sequence in git rev-parse output")
+                        .trim_end()
+                        .to_string()
+                })
+                .ok(),
+            git_branch: Command::new("git")
+                .arg("branch")
+                .arg("--contains")
+                .arg("HEAD")
+                .output()
+                .map(|output| {
+                    String::from_utf8(output.stdout)
+                        .expect("invalid UTF-8 sequence in git branch output")
+                        .trim_end()
+                        .trim_start_matches("* ")
+                        .to_string()
+                })
+                .ok(),
         }
     }
 }


### PR DESCRIPTION
In Windows CI, libgit2-sys takes 2m 9s to compile. It's not in the Cargo timing critical path though, so removing it didn't actually improve build times.