### PR TITLE
Use C++23 preview flag on Windows

### DIFF
--- a/trajoptlib/build.rs
+++ b/trajoptlib/build.rs
@@ -26,7 +26,7 @@ fn main() {
         .include(format!("{}/include/eigen3", cmake_dest.display()))
         .flag_if_supported("-std=c++23")
         .flag_if_supported("-std=c++2b")
-        .flag_if_supported("/std:c++latest");
+        .flag_if_supported("/std:c++23preview");
 
     if cfg!(target_os = "windows") {
         bridge_build.flag("/EHsc").flag("/utf-8");


### PR DESCRIPTION
This should have a more stable ABI than `/std:c++latest`, not that we intend our users to use precompiled versions of TrajoptLibRust anyway.