### PR TITLE
Rework generation dataflow to avoid mutating parameters

### DIFF
--- a/docs/contributing/generation-invariants.md
+++ b/docs/contributing/generation-invariants.md
@@ -1,0 +1,30 @@
+# Generation Invariants
+
+> This is development documentation describing the dataflow as of 5/16/2025. It is not accurate for released versions.
+## Input
+`pre.traj` and `pre.chor`
+* presumed to already be schema-updated to current
+
+## Output
+`post.traj` as serialized  (file write or other response)
+
+`pre.chor` is unchanged
+    * Schema updates might cause the file contents to be replaced with the updated version
+
+
+
+## After Successful Trajectory Generation
+* `name` is unchanged
+* `version` is unchanged
+* `params` is unchanged
+* `snapshot` corresponds to the `params` field
+  * EXCEPT for the waypoint control intervals being different/updated if and only if `override_intervals` is false on a given waypoint
+  * Serializing `snapshot` does not preserve the helper fields is_initial_guess and adjusted_heading, same as how serializing `params` does not preserve them
+* `trajectory` is fully dependent on the generator result, the `snapshot` waypoints' `.intervals` and `.split` fields, and the project type from `pre.chor`
+  * `trajectory.type` is either "Swerve" or "Differential"
+  * `trajectory.waypoints` is a list of timestamps with the same length as `snapshot.waypoints`. Its first element is 0 (seconds).
+  * `trajectory.samples` is the list of samples
+  * `trajectory.splits` is the sample index of every waypoint that starts a split segment. The end waypoint is not included, even if marked split. The start waypoint is always included, even if not marked split. Thus `trajectory.splits` always includes sample index 0 as its first element, and may have other elements.
+
+* `events` is unchanged except that the marker target timestamps are updated as follows for each marker `marker`:
+  * If `marker.from.target` (an index of `snapshot.waypoints`) is not None/undefined and is in bounds, `marker.from.target_timestamp = trajectory.waypoints[marker.from.target]`

--- a/src-core/src/generation/intervals.rs
+++ b/src-core/src/generation/intervals.rs
@@ -44,7 +44,7 @@ pub fn guess_control_interval_count(
             let dx = next.x - this.x;
             let dy = next.y - this.y;
             let distance = dx.hypot(dy);
-            let mut dtheta = angle_modulus(next.heading - this.heading).abs();
+            let mut dtheta = angle_modulus(next.get_heading() - this.get_heading()).abs();
             let max_force = config.wheel_max_torque() / config.radius;
 
             // Default to robotConfig's max velocity and acceleration

--- a/src-core/src/generation/transformers/interval_count.rs
+++ b/src-core/src/generation/transformers/interval_count.rs
@@ -1,19 +1,18 @@
 use trajoptlib::Pose2d;
 
-use crate::{generation::intervals::guess_control_interval_counts, spec::trajectory::Waypoint};
+
+use crate::spec::trajectory::Waypoint;
 
 use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext, SwerveGenerationTransformer};
 
 
 pub struct IntervalCountSetter {
-    counts: Vec<usize>,
     waypoints: Vec<Waypoint<f64>>
 }
 
 impl SwerveGenerationTransformer for IntervalCountSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
             waypoints: context.params.waypoints.clone()
         })
     }
@@ -30,11 +29,11 @@ impl SwerveGenerationTransformer for IntervalCountSetter {
                 let guess_point = Pose2d {
                     x: wpt.x,
                     y: wpt.y,
-                    heading: wpt.heading,
+                    heading: wpt.get_heading(),
                 };
                 guess_points_after_waypoint.push(guess_point);
                 if let Some(last) = control_interval_counts.last_mut() {
-                    *last += self.counts[i];
+                    *last += wpt.intervals;
                 }
             } else {
                 if wpt_cnt > 0 {
@@ -42,15 +41,15 @@ impl SwerveGenerationTransformer for IntervalCountSetter {
                 }
                 guess_points_after_waypoint.clear();
                 if wpt.fix_heading && wpt.fix_translation {
-                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 } else if wpt.fix_translation {
-                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 } else {
-                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 }
                 wpt_cnt += 1;
                 if i != waypoints.len() - 1 {
-                    control_interval_counts.push(self.counts[i]);
+                    control_interval_counts.push(wpt.intervals);
                 }
             }
         }
@@ -62,7 +61,7 @@ impl SwerveGenerationTransformer for IntervalCountSetter {
 impl DifferentialGenerationTransformer for IntervalCountSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
+            
             waypoints: context.params.waypoints.clone()
         })
     }
@@ -79,11 +78,11 @@ impl DifferentialGenerationTransformer for IntervalCountSetter {
                 let guess_point = Pose2d {
                     x: wpt.x,
                     y: wpt.y,
-                    heading: wpt.heading,
+                    heading: wpt.get_heading(),
                 };
                 guess_points_after_waypoint.push(guess_point);
                 if let Some(last) = control_interval_counts.last_mut() {
-                    *last += self.counts[i];
+                    *last += wpt.intervals;
                 }
             } else {
                 if wpt_cnt > 0 {
@@ -91,15 +90,15 @@ impl DifferentialGenerationTransformer for IntervalCountSetter {
                 }
                 guess_points_after_waypoint.clear();
                 if wpt.fix_heading && wpt.fix_translation {
-                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.pose_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 } else if wpt.fix_translation {
-                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.translation_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 } else {
-                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.heading);
+                    generator.empty_wpt(wpt_cnt, wpt.x, wpt.y, wpt.get_heading());
                 }
                 wpt_cnt += 1;
                 if i != waypoints.len() - 1 {
-                    control_interval_counts.push(self.counts[i]);
+                    control_interval_counts.push(wpt.intervals);
                 }
             }
         }

--- a/src-core/src/spec/trajectory.rs
+++ b/src-core/src/spec/trajectory.rs
@@ -18,7 +18,8 @@ pub struct Waypoint<T: SnapshottableType> {
     /// The heading of the waypoint (blue origin).
     ///
     /// Units: radians
-    pub heading: T,
+    #[serde(rename="heading")]
+    pub original_heading: T,
     /// The number of control intervals to use between this waypoint and the next.
     pub intervals: usize,
     /// Whether to split the trajectory at this waypoint.
@@ -33,6 +34,15 @@ pub struct Waypoint<T: SnapshottableType> {
     /// completely invisible to the frontend.
     #[serde(skip, default)]
     pub is_initial_guess: bool,
+    #[serde(skip, default)]
+    pub adjusted_heading: Option<f64>
+}
+
+impl<T: SnapshottableType> Waypoint<T> {
+    pub fn get_heading(&self) -> f64 {
+        let heading = self.original_heading.snapshot();
+        self.adjusted_heading.unwrap_or(heading)
+    }
 }
 
 #[allow(missing_docs)]
@@ -41,13 +51,14 @@ impl<T: SnapshottableType> Waypoint<T> {
         Waypoint {
             x: self.x.snapshot(),
             y: self.y.snapshot(),
-            heading: self.heading.snapshot(),
+            original_heading: self.original_heading.snapshot(),
             intervals: self.intervals,
             split: self.split,
             fix_translation: self.fix_translation,
             fix_heading: self.fix_heading,
             override_intervals: self.override_intervals,
             is_initial_guess: self.is_initial_guess,
+            adjusted_heading: self.adjusted_heading
         }
     }
 }
@@ -502,13 +513,14 @@ mod tests {
             waypoints: vec![Waypoint::<Expr> {
                 x: Expr::fill_in_value(0.0, "m"),
                 y: Expr::fill_in_value(0.0, "m"),
-                heading: Expr::fill_in_value(0.0, "rad"),
+                original_heading: Expr::fill_in_value(0.0, "rad"),
                 intervals: 20,
                 split: false,
                 fix_translation: false,
                 fix_heading: false,
                 override_intervals: false,
                 is_initial_guess: false,
+                adjusted_heading: None
             }],
             constraints: vec![],
             target_dt: Expr::fill_in_value(0.05, "s"),


### PR DESCRIPTION
Previously:
* Mutate parameters to adjust headings (by changing the original heading expression) and identify initial guess points (by changing a nonserialized helper field on Waypoint)
* Take a snapshot of the mutated parameters and use that to set up the SwerveTrajectoryGenerator. 
* During TrajectoryGenerator setup, guess the control interval counts and handle them separately from the snapshot
* After generation, guess the control interval counts *again* and update both the snapshot and the params section with new counts.

This results in bugs where the generator wipes away the expressions in waypoint headings. This was identified as a CLI bug, but it is a core bug that's masked by the way the frontend handles generation results.

New behavior:
* Take a snapshot immediately of the params, never change the params again.
* Mutate clones of the snapshot to adjust headings, identify initial guess points, and store the control interval guess in the `snapshot.waypoints[n].intervals` fields. 
* Set up the TrajectoryGenerator with the modified snapshot.
* After generation, do not update the params section of the trajectory with the updated control interval counts. The snapshot section is the new source of truth for how waypoints correspond to the samples array.


Also this PR has a new docs page explaining what parts of the TrajectoryFile change upon generation.