### PR TITLE
[SystemCore-Alpha] Temporarily remove Pypi publishing

### DIFF
--- a/.github/workflows/choreolib.yml
+++ b/.github/workflows/choreolib.yml
@@ -194,21 +194,21 @@ jobs:
 
       - run: mypy --pretty --show-column-numbers choreolib/py
 
-  pypi-publish:
-    name: Upload release to PyPI
-    runs-on: ubuntu-24.04
-    needs: [build-python]
-    if: github.repository_owner == 'SleipnirGroup' && startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: pypi
-      url: https://pypi.org/p/sleipnirgroup-choreolib
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          pattern: "Python"
-          merge-multiple: true
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  # pypi-publish:
+  #   name: Upload release to PyPI
+  #   runs-on: ubuntu-24.04
+  #   needs: [build-python]
+  #   if: github.repository_owner == 'SleipnirGroup' && startsWith(github.ref, 'refs/tags/v')
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/sleipnirgroup-choreolib
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist
+  #         pattern: "Python"
+  #         merge-multiple: true
+  #     - name: Publish package distributions to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
A non-2027 package was already published unfortunately, but this disables Python publishing during releases until we actually port/update the Python library.