### PR TITLE
Run rustfmt on all files

### DIFF
--- a/src-core/src/generation/transformers/callback.rs
+++ b/src-core/src/generation/transformers/callback.rs
@@ -1,25 +1,32 @@
 use trajoptlib::{DifferentialTrajectory, SwerveTrajectory};
 
-use crate::{generation::generate::{LocalProgressUpdate, PROGRESS_SENDER_LOCK}, ResultExt};
+use crate::{
+    generation::generate::{LocalProgressUpdate, PROGRESS_SENDER_LOCK},
+    ResultExt,
+};
 
-use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext, SwerveGenerationTransformer};
-
+use super::{
+    DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext,
+    SwerveGenerationTransformer,
+};
 
 pub struct CallbackSetter;
 
 fn swerve_status_callback(trajectory: SwerveTrajectory, handle: i64) {
     let tx_opt = PROGRESS_SENDER_LOCK.get();
     if let Some(tx) = tx_opt {
-        let _  = tx.send(LocalProgressUpdate::from(trajectory).handled(handle))
-        .trace_warn();
+        let _ = tx
+            .send(LocalProgressUpdate::from(trajectory).handled(handle))
+            .trace_warn();
     };
 }
 
 fn differential_status_callback(trajectory: DifferentialTrajectory, handle: i64) {
     let tx_opt = PROGRESS_SENDER_LOCK.get();
     if let Some(tx) = tx_opt {
-        let _ = tx.send(LocalProgressUpdate::from(trajectory).handled(handle))
-        .trace_warn();
+        let _ = tx
+            .send(LocalProgressUpdate::from(trajectory).handled(handle))
+            .trace_warn();
     };
 }
 

--- a/src-core/src/generation/transformers/constraints.rs
+++ b/src-core/src/generation/transformers/constraints.rs
@@ -19,7 +19,7 @@ pub struct ConstraintSetter {
     guess_points: Vec<usize>,
     constraint_idx: Vec<ConstraintIDX<f64>>,
     /// A vector of remaining waypoints matching the indexing scheme of constraint_idx
-    waypoint_idx: Vec<Waypoint<f64>>
+    waypoint_idx: Vec<Waypoint<f64>>,
 }
 
 impl ConstraintSetter {
@@ -29,7 +29,8 @@ impl ConstraintSetter {
         let mut waypoint_idx = Vec::<Waypoint<f64>>::new();
         let num_wpts = context.params.waypoints.len();
 
-        context.params
+        context
+            .params
             .waypoints
             .iter()
             .enumerate()
@@ -85,7 +86,7 @@ impl ConstraintSetter {
         FeatureLockedTransformer::always(Self {
             guess_points,
             constraint_idx,
-            waypoint_idx
+            waypoint_idx,
         })
     }
 }
@@ -126,7 +127,7 @@ impl SwerveGenerationTransformer for ConstraintSetter {
                         generator.wpt_linear_velocity_max_magnitude(from, 0.0f64);
                         generator.wpt_angular_velocity_max_magnitude(from, 0.0f64);
                     }
-                },
+                }
                 ConstraintData::KeepInCircle { x, y, r } => match to_opt {
                     None => generator.wpt_keep_in_circle(from, x, y, r),
                     Some(to) => generator.sgmt_keep_in_circle(from, to, x, y, r),
@@ -138,26 +139,19 @@ impl SwerveGenerationTransformer for ConstraintSetter {
                         None => generator.wpt_keep_in_polygon(from, xs, ys),
                         Some(to) => generator.sgmt_keep_in_polygon(from, to, xs, ys),
                     }
-                },
-                ConstraintData::KeepInLane {
-                    tolerance
-                } => {
+                }
+                ConstraintData::KeepInLane { tolerance } => {
                     if let Some(idx_to) = to_opt {
                         if let Some(wpt_from) = self.waypoint_idx.get(from) {
                             if let Some(wpt_to) = self.waypoint_idx.get(idx_to) {
                                 generator.sgmt_keep_in_lane(
-                                    from,
-                                    idx_to,
-                                    wpt_from.x,
-                                    wpt_from.y,
-                                    wpt_to.x,
-                                    wpt_to.y,
+                                    from, idx_to, wpt_from.x, wpt_from.y, wpt_to.x, wpt_to.y,
                                     tolerance,
                                 );
                             }
                         }
                     }
-                },
+                }
                 ConstraintData::KeepOutCircle { x, y, r } => match to_opt {
                     None => generator.wpt_keep_out_circle(from, x, y, r),
                     Some(to) => generator.sgmt_keep_out_circle(from, to, x, y, r),
@@ -216,26 +210,19 @@ impl DifferentialGenerationTransformer for ConstraintSetter {
                         None => generator.wpt_keep_in_polygon(from, xs, ys),
                         Some(to) => generator.sgmt_keep_in_polygon(from, to, xs, ys),
                     }
-                },
-                ConstraintData::KeepInLane {
-                    tolerance
-                } => {
+                }
+                ConstraintData::KeepInLane { tolerance } => {
                     if let Some(idx_to) = to_opt {
                         if let Some(wpt_from) = self.waypoint_idx.get(from) {
                             if let Some(wpt_to) = self.waypoint_idx.get(idx_to) {
                                 generator.sgmt_keep_in_lane(
-                                    from,
-                                    idx_to,
-                                    wpt_from.x,
-                                    wpt_from.y,
-                                    wpt_to.x,
-                                    wpt_to.y,
+                                    from, idx_to, wpt_from.x, wpt_from.y, wpt_to.x, wpt_to.y,
                                     tolerance,
                                 );
                             }
                         }
                     }
-                },
+                }
                 ConstraintData::KeepOutCircle { x, y, r } => match to_opt {
                     None => generator.wpt_keep_out_circle(from, x, y, r),
                     Some(to) => generator.sgmt_keep_out_circle(from, to, x, y, r),

--- a/src-core/src/generation/transformers/drivetrain_and_bumpers.rs
+++ b/src-core/src/generation/transformers/drivetrain_and_bumpers.rs
@@ -2,17 +2,19 @@ use trajoptlib::{DifferentialDrivetrain, SwerveDrivetrain};
 
 use crate::spec::project::RobotConfig;
 
-use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext, SwerveGenerationTransformer};
-
+use super::{
+    DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext,
+    SwerveGenerationTransformer,
+};
 
 pub struct DrivetrainAndBumpersSetter {
-    config: RobotConfig<f64>
+    config: RobotConfig<f64>,
 }
 
 impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            config: context.project.config.snapshot()
+            config: context.project.config.snapshot(),
         })
     }
 
@@ -26,8 +28,7 @@ impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
             wheel_max_angular_velocity: config.vmax / config.gearing,
             wheel_max_torque: config.tmax * config.gearing,
             wheel_cof: config.cof,
-            modules: config
-                .module_translations(),
+            modules: config.module_translations(),
         };
 
         generator.set_drivetrain(&drivetrain);
@@ -35,7 +36,7 @@ impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
             config.bumper.front,
             config.bumper.side,
             config.bumper.side,
-            config.bumper.back
+            config.bumper.back,
         );
     }
 }
@@ -43,7 +44,7 @@ impl SwerveGenerationTransformer for DrivetrainAndBumpersSetter {
 impl DifferentialGenerationTransformer for DrivetrainAndBumpersSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            config: context.project.config.snapshot()
+            config: context.project.config.snapshot(),
         })
     }
 
@@ -65,7 +66,7 @@ impl DifferentialGenerationTransformer for DrivetrainAndBumpersSetter {
             config.bumper.front,
             config.bumper.side,
             config.bumper.side,
-            config.bumper.back
+            config.bumper.back,
         );
     }
 }

--- a/src-core/src/generation/transformers/interval_count.rs
+++ b/src-core/src/generation/transformers/interval_count.rs
@@ -2,19 +2,25 @@ use trajoptlib::Pose2d;
 
 use crate::{generation::intervals::guess_control_interval_counts, spec::trajectory::Waypoint};
 
-use super::{DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext, SwerveGenerationTransformer};
-
+use super::{
+    DifferentialGenerationTransformer, FeatureLockedTransformer, GenerationContext,
+    SwerveGenerationTransformer,
+};
 
 pub struct IntervalCountSetter {
     counts: Vec<usize>,
-    waypoints: Vec<Waypoint<f64>>
+    waypoints: Vec<Waypoint<f64>>,
 }
 
 impl SwerveGenerationTransformer for IntervalCountSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
-            waypoints: context.params.waypoints.clone()
+            counts: guess_control_interval_counts(
+                &context.project.config.snapshot(),
+                &context.params,
+            )
+            .unwrap_or_default(),
+            waypoints: context.params.waypoints.clone(),
         })
     }
 
@@ -62,8 +68,12 @@ impl SwerveGenerationTransformer for IntervalCountSetter {
 impl DifferentialGenerationTransformer for IntervalCountSetter {
     fn initialize(context: &GenerationContext) -> FeatureLockedTransformer<Self> {
         FeatureLockedTransformer::always(Self {
-            counts: guess_control_interval_counts(&context.project.config.snapshot(), &context.params).unwrap_or_default(),
-            waypoints: context.params.waypoints.clone()
+            counts: guess_control_interval_counts(
+                &context.project.config.snapshot(),
+                &context.params,
+            )
+            .unwrap_or_default(),
+            waypoints: context.params.waypoints.clone(),
         })
     }
 


### PR DESCRIPTION
```bash
find . -type f -name '*.rs' -not -path './target/*' -exec rustfmt {} --edition 2021 \;
```
`cargo fmt` is skipping files in `src-core/src/generation/transformers`.
```bash
[tav@myriad Choreo]$ cargo fmt -- -v | grep Formatting | cut -d ' ' -f 2 | cut -d '/' -f 6- | sort 
src-cli/src/main.rs
src-core/src/error.rs
src-core/src/file_management/diagnostics.rs
src-core/src/file_management/formatter.rs
src-core/src/file_management/mod.rs
src-core/src/file_management/upgrader.rs
src-core/src/generation/generate.rs
src-core/src/generation/heading.rs
src-core/src/generation/intervals.rs
src-core/src/generation/mod.rs
src-core/src/generation/remote.rs
src-core/src/generation/transformers/mod.rs
src-core/src/integration_tests/generate.rs
src-core/src/integration_tests/mod.rs
src-core/src/lib.rs
src-core/src/spec/mod.rs
src-core/src/spec/project.rs
src-core/src/spec/project_schema_version.rs
src-core/src/spec/trajectory.rs
src-core/src/spec/traj_schema_version.rs
src-core/src/spec/upgraders.rs
src-tauri/build.rs
src-tauri/src/api.rs
src-tauri/src/built.rs
src-tauri/src/logging.rs
src-tauri/src/main.rs
src-tauri/src/tauri.rs
trajoptlib/build.rs
trajoptlib/examples/differential.rs
trajoptlib/examples/swerve.rs
trajoptlib/src/error.rs
trajoptlib/src/lib.rs
```
https://stackoverflow.com/a/62076924 claims rustfmt skips files whose `macro_rules!` invocations don't produce valid AST nodes.