### PR TITLE
Fix `cargo fmt` not formatting all files

### DIFF
--- a/src-core/src/generation/transformers/mod.rs
+++ b/src-core/src/generation/transformers/mod.rs
@@ -17,17 +17,15 @@ use crate::{
 
 use super::intervals::guess_control_interval_counts;
 
-macro_rules! add_transformers (
-    ($module:ident : $($transformer:ident),*) => {
-        mod $module;
-        $(pub use $module::$transformer;)*
-    };
-);
-
-add_transformers!(interval_count: IntervalCountSetter);
-add_transformers!(drivetrain_and_bumpers: DrivetrainAndBumpersSetter);
-add_transformers!(constraints: ConstraintSetter);
-add_transformers!(callback: CallbackSetter);
+// Add transformers
+mod callback;
+mod constraints;
+mod drivetrain_and_bumpers;
+mod interval_count;
+pub use callback::CallbackSetter;
+pub use constraints::ConstraintSetter;
+pub use drivetrain_and_bumpers::DrivetrainAndBumpersSetter;
+pub use interval_count::IntervalCountSetter;
 
 pub(super) struct GenerationContext {
     pub project: ProjectFile,


### PR DESCRIPTION
Cargo wasn't able to see through the macro to notice the dependent modules. Expanding the macro fixed it and was fewer lines of code anyway.
```bash
[tav@myriad Choreo]$ cargo fmt -- -v | grep Formatting | cut -d ' ' -f 2 | cut -d '/' -f 6- | sort
src-cli/src/main.rs
src-core/src/error.rs
src-core/src/file_management/diagnostics.rs
src-core/src/file_management/formatter.rs
src-core/src/file_management/mod.rs
src-core/src/file_management/upgrader.rs
src-core/src/generation/generate.rs
src-core/src/generation/heading.rs
src-core/src/generation/intervals.rs
src-core/src/generation/mod.rs
src-core/src/generation/remote.rs
src-core/src/generation/transformers/callback.rs
src-core/src/generation/transformers/constraints.rs
src-core/src/generation/transformers/drivetrain_and_bumpers.rs
src-core/src/generation/transformers/interval_count.rs
src-core/src/generation/transformers/mod.rs
src-core/src/integration_tests/generate.rs
src-core/src/integration_tests/mod.rs
src-core/src/lib.rs
src-core/src/spec/mod.rs
src-core/src/spec/project.rs
src-core/src/spec/project_schema_version.rs
src-core/src/spec/trajectory.rs
src-core/src/spec/traj_schema_version.rs
src-core/src/spec/upgraders.rs
src-tauri/build.rs
src-tauri/src/api.rs
src-tauri/src/built.rs
src-tauri/src/logging.rs
src-tauri/src/main.rs
src-tauri/src/tauri.rs
trajoptlib/build.rs
trajoptlib/examples/differential.rs
trajoptlib/examples/swerve.rs
trajoptlib/src/error.rs
trajoptlib/src/lib.rs
```