### PR TITLE
Replace multiline comments with triple forward slash

### DIFF
--- a/choreolib/src/main/native/include/choreo/Choreo.h
+++ b/choreolib/src/main/native/include/choreo/Choreo.h
@@ -24,21 +24,17 @@
 
 namespace choreo {
 
-/**
- * A class that handles loading choreo and caching choreo trajectories.
- */
+/// A class that handles loading choreo and caching choreo trajectories.
 class Choreo {
  public:
-  /**
-   * Load a trajectory from the deploy directory. Choreolib expects .traj files
-   * to be placed in src/main/deploy/choreo/[trajectoryName].traj.
-   *
-   * @tparam SampleType The type of samples in the trajectory.
-   * @param trajectoryName The path name in Choreo, which matches the file name
-   *   in the deploy directory, file extension is optional.
-   * @return The loaded trajectory, or `empty std::optional` if the trajectory
-   *   could not be loaded.
-   */
+  /// Load a trajectory from the deploy directory. Choreolib expects .traj files
+  /// to be placed in src/main/deploy/choreo/[trajectoryName].traj.
+  ///
+  /// @tparam SampleType The type of samples in the trajectory.
+  /// @param trajectoryName The path name in Choreo, which matches the file name
+  ///     in the deploy directory, file extension is optional.
+  /// @return The loaded trajectory, or `empty std::optional` if the trajectory
+  ///     could not be loaded.
   template <TrajectorySample SampleType>
   static std::optional<Trajectory<SampleType>> LoadTrajectory(
       std::string_view trajectoryName) {
@@ -71,16 +67,14 @@ class Choreo {
     return {};
   }
 
-  /**
-   * Load a trajectory from a string.
-   *
-   * @tparam SampleType The type of samples in the trajectory.
-   * @param trajectoryJsonString The JSON string.
-   * @param trajectoryName The path name in Choreo, which matches the file name
-   *   in the deploy directory, file extension is optional.
-   * @return The loaded trajectory, or `empty std::optional` if the trajectory
-   *   could not be loaded.
-   */
+  /// Load a trajectory from a string.
+  ///
+  /// @tparam SampleType The type of samples in the trajectory.
+  /// @param trajectoryJsonString The JSON string.
+  /// @param trajectoryName The path name in Choreo, which matches the file name
+  ///     in the deploy directory, file extension is optional.
+  /// @return The loaded trajectory, or `empty std::optional` if the trajectory
+  ///     could not be loaded.
   template <TrajectorySample SampleType>
   static std::optional<Trajectory<SampleType>> LoadTrajectoryString(
       std::string_view trajectoryJsonString, std::string_view trajectoryName) {
@@ -101,26 +95,22 @@ class Choreo {
     return trajectory;
   }
 
-  /**
-   * A utility for caching loaded trajectories. This allows for loading
-   * trajectories only once, and then reusing them.
-   */
+  /// A utility for caching loaded trajectories. This allows for loading
+  /// trajectories only once, and then reusing them.
   template <TrajectorySample SampleType>
   class TrajectoryCache {
    public:
-    /**
-     * Load a trajectory from the deploy directory. Choreolib expects .traj
-     * files to be placed in src/main/deploy/choreo/[trajectoryName].traj.
-     *
-     * This method will cache the loaded trajectory and reused it if it is
-     * requested again.
-     *
-     * @param trajectoryName the path name in Choreo, which matches the file
-     *     name in the deploy directory, file extension is optional.
-     * @return the loaded trajectory, or `empty std::optional` if the trajectory
-     *     could not be loaded.
-     * @see Choreo#LoadTrajectory(std::string_view)
-     */
+    /// Load a trajectory from the deploy directory. Choreolib expects .traj
+    /// files to be placed in src/main/deploy/choreo/[trajectoryName].traj.
+    ///
+    /// This method will cache the loaded trajectory and reused it if it is
+    /// requested again.
+    ///
+    /// @param trajectoryName the path name in Choreo, which matches the file
+    ///     name in the deploy directory, file extension is optional.
+    /// @return the loaded trajectory, or `empty std::optional` if the
+    ///     trajectory could not be loaded.
+    /// @see Choreo#LoadTrajectory(std::string_view)
     static std::optional<Trajectory<SampleType>> LoadTrajectory(
         std::string_view trajectoryName) {
       if (cache.contains(std::string{trajectoryName})) {
@@ -132,21 +122,20 @@ class Choreo {
       }
     }
 
-    /**
-     * Load a section of a split trajectory from the deploy directory. Choreolib
-     * expects .traj files to be placed in
-     * src/main/deploy/choreo/[trajectoryName].traj.
-     *
-     * This method will cache the loaded trajectory and reused it if it is
-     * requested again. The trajectory that is split off of will also be cached.
-     *
-     * @param trajectoryName the path name in Choreo, which matches the file
-     *     name in the deploy directory, file extension is optional.
-     * @param splitIndex the index of the split trajectory to load
-     * @return the loaded trajectory, or `empty std::optional` if the trajectory
-     *     could not be loaded.
-     * @see Choreo#LoadTrajectory(std::string_view)
-     */
+    /// Load a section of a split trajectory from the deploy directory.
+    /// Choreolib expects .traj files to be placed in
+    /// src/main/deploy/choreo/[trajectoryName].traj.
+    ///
+    /// This method will cache the loaded trajectory and reused it if it is
+    /// requested again. The trajectory that is split off of will also be
+    /// cached.
+    ///
+    /// @param trajectoryName the path name in Choreo, which matches the file
+    ///     name in the deploy directory, file extension is optional.
+    /// @param splitIndex the index of the split trajectory to load
+    /// @return the loaded trajectory, or `empty std::optional` if the
+    ///     trajectory could not be loaded.
+    /// @see Choreo#LoadTrajectory(std::string_view)
     static std::optional<Trajectory<SampleType>> LoadTrajectory(
         std::string_view trajectoryName, int splitIndex) {
       std::string key = fmt::format("{}.:.{}", trajectoryName, splitIndex);
@@ -168,9 +157,7 @@ class Choreo {
       return cache[key];
     }
 
-    /**
-     * Clears the trajectory cache.
-     */
+    /// Clears the trajectory cache.
     static void Clear() { cache.clear(); }
 
    private:

--- a/choreolib/src/main/native/include/choreo/trajectory/DifferentialSample.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/DifferentialSample.h
@@ -24,33 +24,28 @@
 
 namespace choreo {
 
-/**
- * A single differential drive robot sample in a Trajectory.
- */
+/// A single differential drive robot sample in a Trajectory.
 class DifferentialSample {
  public:
-  /**
-   * Constructs a DifferentialSample that is defaulted.
-   */
+  /// Constructs a DifferentialSample that is defaulted.
   constexpr DifferentialSample() = default;
 
-  /**
-   * Constructs a DifferentialSample with the specified parameters.
-   *
-   * @param timestamp The timestamp of this sample, relative to the beginning of
-   * the trajectory.
-   * @param x The X position of the sample
-   * @param y The Y position of the sample
-   * @param heading The heading of the sample, with 0 being in the +X direction.
-   * @param vl The velocity of the left wheels
-   * @param vr The velocity of the right wheels
-   * @param omega The chassis angular velocity
-   * @param al The acceleration of the left wheels
-   * @param ar The acceleration of the left wheels
-   * @param alpha The chassis angular acceleration
-   * @param fl The force of the left wheels
-   * @param fr The force of the right wheels
-   */
+  /// Constructs a DifferentialSample with the specified parameters.
+  ///
+  /// @param timestamp The timestamp of this sample, relative to the beginning
+  ///     of the trajectory.
+  /// @param x The X position of the sample
+  /// @param y The Y position of the sample
+  /// @param heading The heading of the sample, with 0 being in the +X
+  ///     direction.
+  /// @param vl The velocity of the left wheels
+  /// @param vr The velocity of the right wheels
+  /// @param omega The chassis angular velocity
+  /// @param al The acceleration of the left wheels
+  /// @param ar The acceleration of the left wheels
+  /// @param alpha The chassis angular acceleration
+  /// @param fl The force of the left wheels
+  /// @param fr The force of the right wheels
   constexpr DifferentialSample(units::second_t timestamp, units::meter_t x,
                                units::meter_t y, units::radian_t heading,
                                units::meters_per_second_t vl,
@@ -73,37 +68,29 @@ class DifferentialSample {
         fl{fl},
         fr{fr} {}
 
-  /**
-   * Gets the timestamp of the DifferentialSample.
-   *
-   * @return The timestamp.
-   */
+  /// Gets the timestamp of the DifferentialSample.
+  ///
+  /// @return The timestamp.
   units::second_t GetTimestamp() const { return timestamp; }
 
-  /**
-   * Gets the Pose2d of the DifferentialSample.
-   *
-   * @return The pose.
-   */
+  /// Gets the Pose2d of the DifferentialSample.
+  ///
+  /// @return The pose.
   constexpr frc::Pose2d GetPose() const {
     return frc::Pose2d{x, y, frc::Rotation2d{heading}};
   }
 
-  /**
-   * Gets the field-relative chassis speeds of the DifferentialSample.
-   *
-   * @return The field-relative chassis speeds.
-   */
+  /// Gets the field-relative chassis speeds of the DifferentialSample.
+  ///
+  /// @return The field-relative chassis speeds.
   constexpr frc::ChassisSpeeds GetChassisSpeeds() const {
     return frc::ChassisSpeeds{(vl + vr) / 2.0, 0_mps, omega};
   }
 
-  /**
-   * Returns the current sample offset by a the time offset passed in.
-   *
-   * @param timeStampOffset time to move sample by
-   * @return DifferentialSample that is moved forward by the offset
-   */
+  /// Returns the current sample offset by a the time offset passed in.
+  ///
+  /// @param timeStampOffset time to move sample by
+  /// @return DifferentialSample that is moved forward by the offset
   constexpr DifferentialSample OffsetBy(units::second_t timeStampOffset) const {
     return DifferentialSample{timestamp + timeStampOffset,
                               x,
@@ -119,13 +106,11 @@ class DifferentialSample {
                               fr};
   }
 
-  /**
-   * Interpolates between endValue and this by t
-   *
-   * @param endValue the end interpolated value
-   * @param t time to move sample by
-   * @return the interpolated sample
-   */
+  /// Interpolates between endValue and this by t
+  ///
+  /// @param endValue the end interpolated value
+  /// @param t time to move sample by
+  /// @return the interpolated sample
   DifferentialSample Interpolate(const DifferentialSample& endValue,
                                  units::second_t t) const {
     units::scalar_t scale = (t - timestamp) / (endValue.timestamp - timestamp);
@@ -185,12 +170,10 @@ class DifferentialSample {
     };
   }
 
-  /**
-   * Returns the current sample flipped based on the field year.
-   *
-   * @tparam Year The field year.
-   * @return DifferentialSample that is flipped based on the field layout.
-   */
+  /// Returns the current sample flipped based on the field year.
+  ///
+  /// @tparam Year The field year.
+  /// @return DifferentialSample that is flipped based on the field layout.
   template <int Year = util::kDefaultYear>
   constexpr DifferentialSample Flipped() const {
     constexpr auto flipper = choreo::util::GetFlipperForYear<Year>();
@@ -205,12 +188,10 @@ class DifferentialSample {
     }
   }
 
-  /**
-   * DifferentialSample equality operator.
-   *
-   * @param other The other DifferentialSample.
-   * @return True for equality.
-   */
+  /// DifferentialSample equality operator.
+  ///
+  /// @param other The other DifferentialSample.
+  /// @return True for equality.
   constexpr bool operator==(const DifferentialSample& other) const {
     constexpr double epsilon = 1e-6;
 

--- a/choreolib/src/main/native/include/choreo/trajectory/EventMarker.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/EventMarker.h
@@ -9,9 +9,7 @@
 
 namespace choreo {
 
-/**
- * A marker for an event in a trajectory.
- */
+/// A marker for an event in a trajectory.
 struct EventMarker {
   /// The timestamp of the event.
   units::second_t timestamp;
@@ -19,23 +17,19 @@ struct EventMarker {
   /// The event.
   std::string event;
 
-  /**
-   * Returns a new EventMarker with the timestamp offset by the specified
-   * amount.
-   *
-   * @param timestampOffset The amount to offset the timestamp by.
-   * @return A new EventMarker with the timestamp offset by the specified
-   * amount.
-   */
+  /// Returns a new EventMarker with the timestamp offset by the specified
+  /// amount.
+  ///
+  /// @param timestampOffset The amount to offset the timestamp by.
+  /// @return A new EventMarker with the timestamp offset by the specified
+  ///     amount.
   EventMarker OffsetBy(units::second_t timestampOffset) const {
     return EventMarker{timestamp + timestampOffset, event};
   }
 
-  /**
-   * EventMarker equality operator.
-   *
-   * @return True for equality.
-   */
+  /// EventMarker equality operator.
+  ///
+  /// @return True for equality.
   bool operator==(const EventMarker&) const = default;
 };
 

--- a/choreolib/src/main/native/include/choreo/trajectory/SwerveSample.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/SwerveSample.h
@@ -22,35 +22,30 @@
 
 namespace choreo {
 
-/**
- * A single swerve robot sample in a Trajectory.
- */
+/// A single swerve robot sample in a Trajectory.
 class SwerveSample {
  public:
-  /**
-   * Constructs a SwerveSample that is defaulted.
-   */
+  /// Constructs a SwerveSample that is defaulted.
   constexpr SwerveSample() = default;
 
-  /**
-   * Constructs a SwerveSample with the specified parameters.
-   *
-   * @param timestamp The timestamp of this sample, relative to the beginning of
-   * the trajectory.
-   * @param x The X position of the sample
-   * @param y The Y position of the sample
-   * @param heading The heading of the sample, with 0 being in the +X direction.
-   * @param vx The velocity of the sample in the X direction.
-   * @param vy The velocity of the sample in the Y direction.
-   * @param omega The angular velocity of the sample.
-   * @param ax The acceleration of the sample in the X direction.
-   * @param ay The acceleration of the sample in the Y direction.
-   * @param alpha The angular acceleration of the sample.
-   * @param moduleForcesX The force on each swerve module in the X direction.
-   *   Module forces appear in the following order: [FL, FR, BL, BR].
-   * @param moduleForcesY The force on each swerve module in the Y direction.
-   *   Module forces appear in the following order: [FL, FR, BL, BR].
-   */
+  /// Constructs a SwerveSample with the specified parameters.
+  ///
+  /// @param timestamp The timestamp of this sample, relative to the beginning
+  ///     of the trajectory.
+  /// @param x The X position of the sample
+  /// @param y The Y position of the sample
+  /// @param heading The heading of the sample, with 0 being in the +X
+  ///     direction.
+  /// @param vx The velocity of the sample in the X direction.
+  /// @param vy The velocity of the sample in the Y direction.
+  /// @param omega The angular velocity of the sample.
+  /// @param ax The acceleration of the sample in the X direction.
+  /// @param ay The acceleration of the sample in the Y direction.
+  /// @param alpha The angular acceleration of the sample.
+  /// @param moduleForcesX The force on each swerve module in the X direction.
+  ///     Module forces appear in the following order: [FL, FR, BL, BR].
+  /// @param moduleForcesY The force on each swerve module in the Y direction.
+  ///     Module forces appear in the following order: [FL, FR, BL, BR].
   constexpr SwerveSample(units::second_t timestamp, units::meter_t x,
                          units::meter_t y, units::radian_t heading,
                          units::meters_per_second_t vx,
@@ -74,37 +69,29 @@ class SwerveSample {
         moduleForcesX{moduleForcesX},
         moduleForcesY{moduleForcesY} {}
 
-  /**
-   * Gets the timestamp of the SwerveSample.
-   *
-   * @return The timestamp.
-   */
+  /// Gets the timestamp of the SwerveSample.
+  ///
+  /// @return The timestamp.
   constexpr units::second_t GetTimestamp() const { return timestamp; }
 
-  /**
-   * Gets the Pose2d of the SwerveSample.
-   *
-   * @return The pose.
-   */
+  /// Gets the Pose2d of the SwerveSample.
+  ///
+  /// @return The pose.
   constexpr frc::Pose2d GetPose() const {
     return frc::Pose2d{x, y, frc::Rotation2d{heading}};
   }
 
-  /**
-   * Gets the field-relative chassis speeds of the SwerveSample.
-   *
-   * @return The field-relative chassis speeds.
-   */
+  /// Gets the field-relative chassis speeds of the SwerveSample.
+  ///
+  /// @return The field-relative chassis speeds.
   constexpr frc::ChassisSpeeds GetChassisSpeeds() const {
     return frc::ChassisSpeeds{vx, vy, omega};
   }
 
-  /**
-   * Returns the current sample flipped based on the field year.
-   *
-   * @tparam Year The field year.
-   * @return SwerveSample that is flipped based on the field layout.
-   */
+  /// Returns the current sample flipped based on the field year.
+  ///
+  /// @tparam Year The field year.
+  /// @return SwerveSample that is flipped based on the field layout.
   template <int Year = util::kDefaultYear>
   constexpr SwerveSample Flipped() const {
     constexpr auto flipper = choreo::util::GetFlipperForYear<Year>();
@@ -147,12 +134,10 @@ class SwerveSample {
     }
   }
 
-  /**
-   * Returns the current sample offset by a the time offset passed in.
-   *
-   * @param timeStampOffset time to move sample by
-   * @return SwerveSample that is moved forward by the offset
-   */
+  /// Returns the current sample offset by a the time offset passed in.
+  ///
+  /// @param timeStampOffset time to move sample by
+  /// @return SwerveSample that is moved forward by the offset
   constexpr SwerveSample OffsetBy(units::second_t timeStampOffset) const {
     return SwerveSample{timestamp + timeStampOffset,
                         x,
@@ -168,13 +153,11 @@ class SwerveSample {
                         moduleForcesY};
   }
 
-  /**
-   * Interpolates between endValue and this by t
-   *
-   * @param endValue the end interpolated value
-   * @param t time to move sample by
-   * @return the interpolated sample
-   */
+  /// Interpolates between endValue and this by t
+  ///
+  /// @param endValue the end interpolated value
+  /// @param t time to move sample by
+  /// @return the interpolated sample
   constexpr SwerveSample Interpolate(const SwerveSample& endValue,
                                      units::second_t t) const {
     units::scalar_t scale = (t - timestamp) / (endValue.timestamp - timestamp);
@@ -212,12 +195,10 @@ class SwerveSample {
                         interpolatedForcesY};
   }
 
-  /**
-   * SwerveSample equality operator.
-   *
-   * @param other The other SwerveSample.
-   * @return True for equality.
-   */
+  /// SwerveSample equality operator.
+  ///
+  /// @param other The other SwerveSample.
+  /// @return True for equality.
   constexpr bool operator==(const SwerveSample& other) const {
     constexpr double epsilon = 1e-6;
 

--- a/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/Trajectory.h
@@ -20,27 +20,21 @@
 
 namespace choreo {
 
-/**
- * A trajectory loaded from Choreo.
- *
- * @param <SampleType> DifferentialSample or SwerveSample.
- */
+/// A trajectory loaded from Choreo.
+///
+/// @tparam SampleType DifferentialSample or SwerveSample.
 template <TrajectorySample SampleType>
 class Trajectory {
  public:
-  /**
-   * Constructs a Trajectory with defaults
-   */
+  /// Constructs a Trajectory with defaults
   Trajectory() = default;
 
-  /**
-   * Constructs a Trajectory with the specified parameters.
-   *
-   * @param name The name of the trajectory.
-   * @param samples The samples of the trajectory.
-   * @param splits The indices of the splits in the trajectory.
-   * @param events The events in the trajectory.
-   */
+  /// Constructs a Trajectory with the specified parameters.
+  ///
+  /// @param name The name of the trajectory.
+  /// @param samples The samples of the trajectory.
+  /// @param splits The indices of the splits in the trajectory.
+  /// @param events The events in the trajectory.
   Trajectory(std::string_view name, std::vector<SampleType> samples,
              std::vector<int> splits, std::vector<EventMarker> events)
       : name{name},
@@ -48,15 +42,13 @@ class Trajectory {
         splits{std::move(splits)},
         events{std::move(events)} {}
 
-  /**
-   * Returns the first SampleType in the trajectory.
-   *
-   * Will return an empty optional if the trajectory is empty
-   *
-   * @param mirrorForRedAlliance whether or not to return the sample as mirrored
-   *   across the field
-   * @return The first sample in the trajectory.
-   */
+  /// Returns the first SampleType in the trajectory.
+  ///
+  /// Will return an empty optional if the trajectory is empty
+  ///
+  /// @param mirrorForRedAlliance whether or not to return the sample as
+  ///     mirrored across the field
+  /// @return The first sample in the trajectory.
   std::optional<SampleType> GetInitialSample(
       bool mirrorForRedAlliance = false) const {
     if (samples.size() == 0) {
@@ -65,15 +57,13 @@ class Trajectory {
     return mirrorForRedAlliance ? samples.front().Flipped() : samples.front();
   }
 
-  /**
-   * Returns the last SampleType in the trajectory.
-   *
-   * Will return an empty optional if the trajectory is empty
-   *
-   * @param mirrorForRedAlliance whether or not to return the sample as mirrored
-   *   across the field
-   * @return The last sample in the trajectory.
-   */
+  /// Returns the last SampleType in the trajectory.
+  ///
+  /// Will return an empty optional if the trajectory is empty
+  ///
+  /// @param mirrorForRedAlliance whether or not to return the sample as
+  ///     mirrored across the field
+  /// @return The last sample in the trajectory.
   std::optional<SampleType> GetFinalSample(
       bool mirrorForRedAlliance = false) const {
     if (samples.size() == 0) {
@@ -82,17 +72,15 @@ class Trajectory {
     return mirrorForRedAlliance ? samples.back().Flipped() : samples.back();
   }
 
-  /**
-   * Return an interpolated sample of the trajectory at the given timestamp.
-   *
-   * This function will return an empty optional if the trajectory is empty.
-   *
-   * @tparam Year The field year. Defaults to the current year.
-   * @param timestamp The timestamp of this sample relative to the beginning of
-   * the trajectory.
-   * @param mirrorForRedAlliance whether or not to return the sample mirrored.
-   * @return The SampleType at the given time.
-   */
+  /// Return an interpolated sample of the trajectory at the given timestamp.
+  ///
+  /// This function will return an empty optional if the trajectory is empty.
+  ///
+  /// @tparam Year The field year. Defaults to the current year.
+  /// @param timestamp The timestamp of this sample relative to the beginning of
+  ///     the trajectory.
+  /// @param mirrorForRedAlliance whether or not to return the sample mirrored.
+  /// @return The SampleType at the given time.
   template <int Year = util::kDefaultYear>
   std::optional<SampleType> SampleAt(units::second_t timestamp,
                                      bool mirrorForRedAlliance = false) const {
@@ -104,15 +92,13 @@ class Trajectory {
     }
   }
 
-  /**
-   * Returns the first Pose in the trajectory.
-   *
-   * Will return an empty optional if the trajectory is empty
-   *
-   * @tparam Year The field year. Defaults to the current year.
-   * @param mirrorForRedAlliance whether or not to return the Pose mirrored.
-   * @return The first Pose in the trajectory.
-   */
+  /// Returns the first Pose in the trajectory.
+  ///
+  /// Will return an empty optional if the trajectory is empty
+  ///
+  /// @tparam Year The field year. Defaults to the current year.
+  /// @param mirrorForRedAlliance whether or not to return the Pose mirrored.
+  /// @return The first Pose in the trajectory.
   template <int Year = util::kDefaultYear>
   std::optional<frc::Pose2d> GetInitialPose(
       bool mirrorForRedAlliance = false) const {
@@ -126,15 +112,13 @@ class Trajectory {
     }
   }
 
-  /**
-   * Returns the last Pose in the trajectory.
-   *
-   * Will return an empty optional if the trajectory is empty
-   *
-   * @tparam Year The field year. Defaults to the current year.
-   * @param mirrorForRedAlliance whether or not to return the Pose mirrored.
-   * @return The last Pose in the trajectory.
-   */
+  /// Returns the last Pose in the trajectory.
+  ///
+  /// Will return an empty optional if the trajectory is empty
+  ///
+  /// @tparam Year The field year. Defaults to the current year.
+  /// @param mirrorForRedAlliance whether or not to return the Pose mirrored.
+  /// @return The last Pose in the trajectory.
   template <int Year = util::kDefaultYear>
   std::optional<frc::Pose2d> GetFinalPose(
       bool mirrorForRedAlliance = false) const {
@@ -148,12 +132,10 @@ class Trajectory {
     }
   }
 
-  /**
-   * The total time the trajectory will take to follow
-   *
-   * @return The total time the trajectory will take to follow, if empty will
-   * return 0 seconds.
-   */
+  /// The total time the trajectory will take to follow
+  ///
+  /// @return The total time the trajectory will take to follow, if empty will
+  ///     return 0 seconds.
   units::second_t GetTotalTime() const {
     if (samples.size() == 0) {
       return 0_s;
@@ -161,11 +143,9 @@ class Trajectory {
     return GetFinalSample().value().GetTimestamp();
   }
 
-  /**
-   * Returns the vector of poses corresponding to the trajectory.
-   *
-   * @return the vector of poses corresponding to the trajectory.
-   */
+  /// Returns the vector of poses corresponding to the trajectory.
+  ///
+  /// @return the vector of poses corresponding to the trajectory.
   std::vector<frc::Pose2d> GetPoses() const {
     std::vector<frc::Pose2d> poses;
     for (const auto& sample : samples) {
@@ -174,12 +154,10 @@ class Trajectory {
     return poses;
   }
 
-  /**
-   * Returns this trajectory, mirrored across the field midline.
-   *
-   * @tparam Year The field year. Defaults to the current year.
-   * @return this trajectory, mirrored across the field midline.
-   */
+  /// Returns this trajectory, mirrored across the field midline.
+  ///
+  /// @tparam Year The field year. Defaults to the current year.
+  /// @return this trajectory, mirrored across the field midline.
   template <int Year = util::kDefaultYear>
   Trajectory<SampleType> Flipped() const {
     std::vector<SampleType> flippedStates;
@@ -189,13 +167,11 @@ class Trajectory {
     return Trajectory<SampleType>(name, flippedStates, splits, events);
   }
 
-  /**
-   * Returns a vector of all events with the given name in the trajectory.
-   *
-   * @param eventName The name of the event.
-   * @return A vector of all events with the given name in the trajectory, if no
-   * events are found, an empty vector is returned.
-   */
+  /// Returns a vector of all events with the given name in the trajectory.
+  ///
+  /// @param eventName The name of the event.
+  /// @return A vector of all events with the given name in the trajectory, if
+  ///     no events are found, an empty vector is returned.
   std::vector<EventMarker> GetEvents(std::string_view eventName) const {
     std::vector<EventMarker> matchingEvents;
     for (const auto& event : events) {
@@ -206,14 +182,12 @@ class Trajectory {
     return matchingEvents;
   }
 
-  /**
-   * Returns a choreo trajectory that represents the split of the trajectory at
-   * the given index.
-   *
-   * @param splitIndex the index of the split trajectory to return.
-   * @return a choreo trajectory that represents the split of the trajectory at
-   * the given index.
-   */
+  /// Returns a choreo trajectory that represents the split of the trajectory at
+  /// the given index.
+  ///
+  /// @param splitIndex the index of the split trajectory to return.
+  /// @return a choreo trajectory that represents the split of the trajectory at
+  ///     the given index.
   std::optional<Trajectory<SampleType>> GetSplit(int splitIndex) const {
     // Assumption: splits[splitIndex] is a valid index of samples.
     if (splitIndex < 0 || splitIndex >= splits.size()) {
@@ -255,12 +229,10 @@ class Trajectory {
         std::vector<EventMarker>(filteredEvents.begin(), filteredEvents.end())};
   }
 
-  /**
-   * Trajectory equality operator.
-   *
-   * @param other The other trajectory.
-   * @return True for equality.
-   */
+  /// Trajectory equality operator.
+  ///
+  /// @param other The other trajectory.
+  /// @return True for equality.
   bool operator==(const Trajectory<SampleType>& other) const {
     if (name != other.name) {
       return false;

--- a/choreolib/src/main/native/include/choreo/trajectory/TrajectorySample.h
+++ b/choreolib/src/main/native/include/choreo/trajectory/TrajectorySample.h
@@ -10,18 +10,14 @@
 
 namespace choreo {
 
-/**
- * Enforce equality operators on trajectory sample types.
- */
+/// Enforce equality operators on trajectory sample types.
 template <typename T>
 concept EqualityComparable = requires(const T& a, const T& b) {
   { a == b } -> std::convertible_to<bool>;
   { a != b } -> std::convertible_to<bool>;
 };
 
-/**
- * A concept representing a single robot sample in a Trajectory.
- */
+/// A concept representing a single robot sample in a Trajectory.
 template <typename T>
 concept TrajectorySample =
     EqualityComparable<T> &&

--- a/choreolib/src/main/native/include/choreo/util/AllianceFlipperUtil.h
+++ b/choreolib/src/main/native/include/choreo/util/AllianceFlipperUtil.h
@@ -16,77 +16,61 @@ namespace choreo::util {
 
 enum class FlipperType { Mirrored, RotateAround };
 
-/**
- * X becomes fieldLength - x, leaves the y coordinate unchanged, and heading
- * becomes pi - heading.
- */
+/// X becomes fieldLength - x, leaves the y coordinate unchanged, and heading
+/// becomes pi - heading.
 struct MirroredFlipper {
   /// Whether pose should be mirrored.
   static constexpr bool isMirrored = true;
 
-  /**
-   * Flips the X coordinate.
-   *
-   * @param x The X coordinate to flip.
-   * @return The flipped X coordinate.
-   */
+  /// Flips the X coordinate.
+  ///
+  /// @param x The X coordinate to flip.
+  /// @return The flipped X coordinate.
   static constexpr units::meter_t FlipX(units::meter_t x) {
     return fieldLength - x;
   }
 
-  /**
-   * Flips the Y coordinate.
-   *
-   * @param y The Y coordinate to flip.
-   * @return The flipped Y coordinate.
-   */
+  /// Flips the Y coordinate.
+  ///
+  /// @param y The Y coordinate to flip.
+  /// @return The flipped Y coordinate.
   static constexpr units::meter_t FlipY(units::meter_t y) { return y; }
 
-  /**
-   * Flips the heading.
-   *
-   * @param heading The heading to flip.
-   * @return The flipped heading.
-   */
+  /// Flips the heading.
+  ///
+  /// @param heading The heading to flip.
+  /// @return The flipped heading.
   static constexpr units::radian_t FlipHeading(units::radian_t heading) {
     return units::radian_t{std::numbers::pi} - heading;
   }
 };
 
-/**
- * X becomes fieldLength - x, Y becomes fieldWidth - y, and heading becomes pi -
- * heading.
- */
+/// X becomes fieldLength - x, Y becomes fieldWidth - y, and heading becomes
+/// pi - heading.
 struct RotateAroundFlipper {
   /// Whether pose should be mirrored.
   static constexpr bool isMirrored = false;
 
-  /**
-   * Flips the X coordinate.
-   *
-   * @param x The X coordinate to flip.
-   * @return The flipped X coordinate.
-   */
+  /// Flips the X coordinate.
+  ///
+  /// @param x The X coordinate to flip.
+  /// @return The flipped X coordinate.
   static constexpr units::meter_t FlipX(units::meter_t x) {
     return fieldLength - x;
   }
 
-  /**
-   * Flips the Y coordinate.
-   *
-   * @param y The Y coordinate to flip.
-   * @return The flipped Y coordinate.
-   */
+  /// Flips the Y coordinate.
+  ///
+  /// @param y The Y coordinate to flip.
+  /// @return The flipped Y coordinate.
   static constexpr units::meter_t FlipY(units::meter_t y) {
     return fieldWidth - y;
   }
 
-  /**
-   * Flips the heading.
-   *
-   * @param heading The heading to flip.
-   * @return The flipped heading.
-   */
+  /// Flips the heading.
+  ///
+  /// @param heading The heading to flip.
+  /// @return The flipped heading.
   static constexpr units::radian_t FlipHeading(units::radian_t heading) {
     return units::radian_t{std::numbers::pi} + heading;
   }
@@ -100,15 +84,13 @@ inline constexpr Map flipperMap{
 
 inline constexpr int kDefaultYear = 2025;
 
-/**
- * A utility to standardize flipping of coordinate data based on the current
- * alliance across different years.
- *
- * Grabs the instance of the flipper for the supplied template parameter. Will
- * not compile if an invalid year is supplied.
- *
- * @tparam Year The field year. Defaults to the current year.
- */
+/// A utility to standardize flipping of coordinate data based on the current
+/// alliance across different years.
+///
+/// Grabs the instance of the flipper for the supplied template parameter. Will
+/// not compile if an invalid year is supplied.
+///
+/// @tparam Year The field year. Defaults to the current year.
 template <int Year = kDefaultYear>
 constexpr auto GetFlipperForYear() {
   constexpr bool yearInMap = [] {

--- a/choreolib/src/main/native/include/choreo/util/Map.h
+++ b/choreolib/src/main/native/include/choreo/util/Map.h
@@ -9,31 +9,25 @@
 
 namespace choreo::util {
 
-/**
- * A compile-time associative container.
- *
- * @tparam Key The key type.
- * @tparam Value The value type.
- * @tparam Size The number of elements in the container.
- */
+/// A compile-time associative container.
+///
+/// @tparam Key The key type.
+/// @tparam Value The value type.
+/// @tparam Size The number of elements in the container.
 template <typename Key, typename Value, size_t Size>
 class Map {
  public:
-  /**
-   * Construct the map from an array of key-value pairs.
-   *
-   * @param data The key-value pairs.
-   */
+  /// Construct the map from an array of key-value pairs.
+  ///
+  /// @param data The key-value pairs.
   explicit constexpr Map(const std::array<std::pair<Key, Value>, Size>& data)
       : data{data} {}
 
-  /**
-   * Returns the value associated with the given key.
-   *
-   * @param key The key.
-   * @return The value.
-   * @throws std::range_error if the key wasn't found.
-   */
+  /// Returns the value associated with the given key.
+  ///
+  /// @param key The key.
+  /// @return The value.
+  /// @throws std::range_error if the key wasn't found.
   [[nodiscard]]
   constexpr const Value& at(const Key& key) const {
     if (const auto it =

--- a/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
+++ b/choreolib/src/test/java/choreo/auto/PoseFlippingTest.java
@@ -23,10 +23,8 @@ public class PoseFlippingTest {
   AutoFactory factoryFlip;
   AutoFactory factoryNoFlip;
 
-  /**
-   * Test for a pose that flips when flipping is enabled and alliance is red, is unflipped whenever
-   * flipping is disabled, and is empty when flipping is enabled and alliance is empty
-   */
+  /// Test for a pose that flips when flipping is enabled and alliance is red, is unflipped whenever
+  /// flipping is disabled, and is empty when flipping is enabled and alliance is empty
   void testPoseProperlyFlipped(
       Pose2d unflipped, Pose2d flipped, Supplier<Optional<Pose2d>> poseToTest) {
     setAlliance(Optional.empty());

--- a/src-core/src/generation/generate.rs
+++ b/src-core/src/generation/generate.rs
@@ -14,11 +14,9 @@ use crate::ChoreoResult;
 use crate::spec::project::ProjectFile;
 use crate::spec::trajectory::{ConstraintScope, Sample, TrajectoryFile};
 
-/**
- * A [`OnceLock`] is a synchronization primitive that can be written to
- * once. Used here to create a read-only static reference to the sender,
- * even though the sender can't be constructed in a static context.
- */
+/// A [`OnceLock`] is a synchronization primitive that can be written to once.
+/// Used here to create a read-only static reference to the sender, even though
+/// the sender can't be constructed in a static context.
 pub(super) static PROGRESS_SENDER_LOCK: OnceLock<Sender<HandledLocalProgressUpdate>> =
     OnceLock::new();
 

--- a/src-core/src/generation/mod.rs
+++ b/src-core/src/generation/mod.rs
@@ -3,9 +3,7 @@ pub mod heading;
 pub mod intervals;
 pub mod remote;
 
-/**
- * A port of `WPILib`'s MathUtil.inputModulus
- */
+/// A port of `WPILib`'s MathUtil.inputModulus
 #[must_use]
 pub fn input_modulus(input: f64, maximum_input: f64, minimum_input: f64) -> f64 {
     let mut val = input;
@@ -22,9 +20,7 @@ pub fn input_modulus(input: f64, maximum_input: f64, minimum_input: f64) -> f64 
     val
 }
 
-/**
- * A port of `WPILib`'s MathUtil.angleModulus
- */
+/// A port of `WPILib`'s MathUtil.angleModulus
 #[must_use]
 pub fn angle_modulus(input: f64) -> f64 {
     use std::f64::consts::PI;

--- a/src-core/src/generation/remote.rs
+++ b/src-core/src/generation/remote.rs
@@ -35,9 +35,7 @@ pub struct RemoteGenerationResources {
 }
 
 impl RemoteGenerationResources {
-    /**
-     * Should be called after [`setup_progress_sender`] to ensure that the sender is initialized.
-     */
+    /// Should be called after [`setup_progress_sender`] to ensure that the sender is initialized.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {

--- a/trajoptlib/include/trajopt/constraint/angular_velocity_max_magnitude_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/angular_velocity_max_magnitude_constraint.hpp
@@ -13,32 +13,26 @@
 
 namespace trajopt {
 
-/**
- * Angular velocity max magnitude inequality constraint.
- */
+/// Angular velocity max magnitude inequality constraint.
 class TRAJOPT_DLLEXPORT AngularVelocityMaxMagnitudeConstraint {
  public:
-  /**
-   * Constructs an AngularVelocityMaxMagnitudeConstraint.
-   *
-   * @param max_magnitude The maximum angular velocity magnitude. Must be
-   *     nonnegative.
-   */
+  /// Constructs an AngularVelocityMaxMagnitudeConstraint.
+  ///
+  /// @param max_magnitude The maximum angular velocity magnitude. Must be
+  ///     nonnegative.
   explicit AngularVelocityMaxMagnitudeConstraint(double max_magnitude)
       : m_max_magnitude{max_magnitude} {
     assert(max_magnitude >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem,
       [[maybe_unused]] const Pose2v<double>& pose,

--- a/trajoptlib/include/trajopt/constraint/constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/constraint.hpp
@@ -26,16 +26,14 @@
 
 namespace trajopt {
 
-/**
- * ConstraintType concept.
- *
- * To make TrajoptLib support a new constraint type, do the following in this
- * file:
- *
- * 1. Include the type's header file
- * 2. Add a constraint static assert for the type
- * 3. Add the type to Constraint's std::variant type list
- */
+/// ConstraintType concept.
+///
+/// To make TrajoptLib support a new constraint type, do the following in this
+/// file:
+///
+/// 1. Include the type's header file
+/// 2. Add a constraint static assert for the type
+/// 3. Add the type to Constraint's std::variant type list
 template <typename T>
 concept ConstraintType =
     requires(T self, slp::Problem<double>& problem, const Pose2v<double>& pose,

--- a/trajoptlib/include/trajopt/constraint/lane_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/lane_constraint.hpp
@@ -12,21 +12,17 @@
 
 namespace trajopt {
 
-/**
- * Lane Constraint.
- *
- * Specifies the robot must stay between two lines.
- */
+/// Lane Constraint.
+///
+/// Specifies the robot must stay between two lines.
 class TRAJOPT_DLLEXPORT LaneConstraint {
  public:
-  /**
-   * Constructs a LaneConstraint.
-   *
-   * @param center_line_start Start point of the center line.
-   * @param center_line_end End point of the center line.
-   * @param tolerance Distance from center line to lane edge. Passing zero
-   *   creates a line constraint.
-   */
+  /// Constructs a LaneConstraint.
+  ///
+  /// @param center_line_start Start point of the center line.
+  /// @param center_line_end End point of the center line.
+  /// @param tolerance Distance from center line to lane edge. Passing zero
+  ///     creates a line constraint.
   LaneConstraint(Translation2d center_line_start, Translation2d center_line_end,
                  double tolerance)
       : m_top_line{[&] {
@@ -63,16 +59,14 @@ class TRAJOPT_DLLEXPORT LaneConstraint {
           }
         }()} {}
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(slp::Problem<double>& problem, const Pose2v<double>& pose,
              const Translation2v<double>& linear_velocity,
              const slp::Variable<double>& angular_velocity,

--- a/trajoptlib/include/trajopt/constraint/line_point_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/line_point_constraint.hpp
@@ -15,23 +15,19 @@
 
 namespace trajopt {
 
-/**
- * Line-point constraint.
- *
- * Specifies the required minimum distance between a line segment on the
- * robot's frame and a point on the field.
- */
+/// Line-point constraint.
+///
+/// Specifies the required minimum distance between a line segment on the
+/// robot's frame and a point on the field.
 class TRAJOPT_DLLEXPORT LinePointConstraint {
  public:
-  /**
-   * Constructs a LinePointConstraint.
-   *
-   * @param robot_line_start Robot line start.
-   * @param robot_line_end Robot line end.
-   * @param field_point Field point.
-   * @param min_distance Minimum distance between robot line and field point.
-   *     Must be nonnegative.
-   */
+  /// Constructs a LinePointConstraint.
+  ///
+  /// @param robot_line_start Robot line start.
+  /// @param robot_line_end Robot line end.
+  /// @param field_point Field point.
+  /// @param min_distance Minimum distance between robot line and field point.
+  ///     Must be nonnegative.
   explicit LinePointConstraint(Translation2d robot_line_start,
                                Translation2d robot_line_end,
                                Translation2d field_point, double min_distance)
@@ -42,16 +38,14 @@ class TRAJOPT_DLLEXPORT LinePointConstraint {
     assert(min_distance >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/linear_acceleration_max_magnitude_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/linear_acceleration_max_magnitude_constraint.hpp
@@ -13,32 +13,26 @@
 
 namespace trajopt {
 
-/**
- * Linear acceleration max magnitude inequality constraint.
- */
+/// Linear acceleration max magnitude inequality constraint.
 class TRAJOPT_DLLEXPORT LinearAccelerationMaxMagnitudeConstraint {
  public:
-  /**
-   * Constructs a LinearAccelerationMaxMagnitudeConstraint.
-   *
-   * @param max_magnitude The maximum linear acceleration magnitude. Must be
-   *     nonnegative.
-   */
+  /// Constructs a LinearAccelerationMaxMagnitudeConstraint.
+  ///
+  /// @param max_magnitude The maximum linear acceleration magnitude. Must be
+  ///     nonnegative.
   explicit LinearAccelerationMaxMagnitudeConstraint(double max_magnitude)
       : m_max_magnitude{max_magnitude} {
     assert(max_magnitude >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem,
       [[maybe_unused]] const Pose2v<double>& pose,

--- a/trajoptlib/include/trajopt/constraint/linear_velocity_direction_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/linear_velocity_direction_constraint.hpp
@@ -11,28 +11,22 @@
 
 namespace trajopt {
 
-/**
- * Linear velocity direction equality constraint.
- */
+/// Linear velocity direction equality constraint.
 class TRAJOPT_DLLEXPORT LinearVelocityDirectionConstraint {
  public:
-  /**
-   * Constructs a LinearVelocityDirectionConstraint.
-   *
-   * @param angle The angle (radians).
-   */
+  /// Constructs a LinearVelocityDirectionConstraint.
+  ///
+  /// @param angle The angle (radians).
   explicit LinearVelocityDirectionConstraint(double angle) : m_angle{angle} {}
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       [[maybe_unused]] slp::Problem<double>& problem,
       [[maybe_unused]] const Pose2v<double>& pose,

--- a/trajoptlib/include/trajopt/constraint/linear_velocity_max_magnitude_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/linear_velocity_max_magnitude_constraint.hpp
@@ -13,32 +13,26 @@
 
 namespace trajopt {
 
-/**
- * Linear velocity max magnitude inequality constraint.
- */
+/// Linear velocity max magnitude inequality constraint.
 class TRAJOPT_DLLEXPORT LinearVelocityMaxMagnitudeConstraint {
  public:
-  /**
-   * Constructs a LinearVelocityMaxMagnitudeConstraint.
-   *
-   * @param max_magnitude The maximum linear velocity magnitude. Must be
-   *     nonnegative.
-   */
+  /// Constructs a LinearVelocityMaxMagnitudeConstraint.
+  ///
+  /// @param max_magnitude The maximum linear velocity magnitude. Must be
+  ///     nonnegative.
   explicit LinearVelocityMaxMagnitudeConstraint(double max_magnitude)
       : m_max_magnitude{max_magnitude} {
     assert(max_magnitude >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem,
       [[maybe_unused]] const Pose2v<double>& pose,

--- a/trajoptlib/include/trajopt/constraint/point_at_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/point_at_constraint.hpp
@@ -14,22 +14,18 @@
 
 namespace trajopt {
 
-/**
- * Point-at constraint.
- *
- * Specifies a point on the field at which the robot should point.
- */
+/// Point-at constraint.
+///
+/// Specifies a point on the field at which the robot should point.
 class TRAJOPT_DLLEXPORT PointAtConstraint {
  public:
-  /**
-   * Constructs a PointAtConstraint.
-   *
-   * @param field_point Field point.
-   * @param heading_tolerance The allowed robot heading tolerance (radians).
-   *     Must be nonnegative.
-   * @param flip False points at the field point while true points away from the
-   *     field point.
-   */
+  /// Constructs a PointAtConstraint.
+  ///
+  /// @param field_point Field point.
+  /// @param heading_tolerance The allowed robot heading tolerance (radians).
+  ///     Must be nonnegative.
+  /// @param flip False points at the field point while true points away from
+  ///     the field point.
   explicit PointAtConstraint(Translation2d field_point,
                              double heading_tolerance, bool flip = false)
       : m_field_point{std::move(field_point)},
@@ -38,16 +34,14 @@ class TRAJOPT_DLLEXPORT PointAtConstraint {
     assert(m_heading_tolerance >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/point_line_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/point_line_constraint.hpp
@@ -15,23 +15,19 @@
 
 namespace trajopt {
 
-/**
- * Point-line constraint.
- *
- * Specifies the required minimum distance between a point on the robot's frame
- * and a line segment on the field.
- */
+/// Point-line constraint.
+///
+/// Specifies the required minimum distance between a point on the robot's frame
+/// and a line segment on the field.
 class TRAJOPT_DLLEXPORT PointLineConstraint {
  public:
-  /**
-   * Constructs a PointLineConstraint.
-   *
-   * @param robot_point Robot point.
-   * @param field_line_start Field line start.
-   * @param field_line_end Field line end.
-   * @param min_distance Minimum distance between robot point and field line.
-   *     Must be nonnegative.
-   */
+  /// Constructs a PointLineConstraint.
+  ///
+  /// @param robot_point Robot point.
+  /// @param field_line_start Field line start.
+  /// @param field_line_end Field line end.
+  /// @param min_distance Minimum distance between robot point and field line.
+  ///     Must be nonnegative.
   explicit PointLineConstraint(Translation2d robot_point,
                                Translation2d field_line_start,
                                Translation2d field_line_end,
@@ -43,16 +39,14 @@ class TRAJOPT_DLLEXPORT PointLineConstraint {
     assert(min_distance >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/point_line_region_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/point_line_region_constraint.hpp
@@ -15,9 +15,7 @@
 
 namespace trajopt {
 
-/**
- * The side of the line to stay on.
- */
+/// The side of the line to stay on.
 enum class Side : uint8_t {
   /// Stay above the line.
   ABOVE,
@@ -27,22 +25,18 @@ enum class Side : uint8_t {
   ON,
 };
 
-/**
- * Point-line region constraint.
- *
- * Specifies that a point on the robot must be on one side of a line defined by
- * two points on the field
- */
+/// Point-line region constraint.
+///
+/// Specifies that a point on the robot must be on one side of a line defined by
+/// two points on the field
 class TRAJOPT_DLLEXPORT PointLineRegionConstraint {
  public:
-  /**
-   * Constructs a PointLineRegionConstraint.
-   *
-   * @param robot_point Robot point.
-   * @param field_line_start Field line start.
-   * @param field_line_end Field line end.
-   * @param side The side to constrain the robot to.
-   */
+  /// Constructs a PointLineRegionConstraint.
+  ///
+  /// @param robot_point Robot point.
+  /// @param field_line_start Field line start.
+  /// @param field_line_end Field line end.
+  /// @param side The side to constrain the robot to.
   explicit PointLineRegionConstraint(Translation2d robot_point,
                                      Translation2d field_line_start,
                                      Translation2d field_line_end, Side side)
@@ -51,16 +45,14 @@ class TRAJOPT_DLLEXPORT PointLineRegionConstraint {
         m_field_line_end{std::move(field_line_end)},
         m_side{side} {}
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/point_point_max_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/point_point_max_constraint.hpp
@@ -14,22 +14,18 @@
 
 namespace trajopt {
 
-/**
- * Point-point constraint.
- *
- * Specifies the required maximum distance between a point on the robot's frame
- * and a point on the field.
- */
+/// Point-point constraint.
+///
+/// Specifies the required maximum distance between a point on the robot's frame
+/// and a point on the field.
 class TRAJOPT_DLLEXPORT PointPointMaxConstraint {
  public:
-  /**
-   * Constructs a LinePointConstraint.
-   *
-   * @param robot_point Robot point.
-   * @param field_point Field point.
-   * @param max_distance Maximum distance between robot line and field point.
-   *     Must be nonnegative.
-   */
+  /// Constructs a LinePointConstraint.
+  ///
+  /// @param robot_point Robot point.
+  /// @param field_point Field point.
+  /// @param max_distance Maximum distance between robot line and field point.
+  ///     Must be nonnegative.
   explicit PointPointMaxConstraint(Translation2d robot_point,
                                    Translation2d field_point,
                                    double max_distance)
@@ -39,16 +35,14 @@ class TRAJOPT_DLLEXPORT PointPointMaxConstraint {
     assert(max_distance >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/point_point_min_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/point_point_min_constraint.hpp
@@ -14,22 +14,18 @@
 
 namespace trajopt {
 
-/**
- * Point-point constraint.
- *
- * Specifies the required minimum distance between a point on the robot's frame
- * and a point on the field.
- */
+/// Point-point constraint.
+///
+/// Specifies the required minimum distance between a point on the robot's frame
+/// and a point on the field.
 class TRAJOPT_DLLEXPORT PointPointMinConstraint {
  public:
-  /**
-   * Constructs a LinePointConstraint.
-   *
-   * @param robot_point Robot point.
-   * @param field_point Field point.
-   * @param min_distance Minimum distance between robot line and field point.
-   *     Must be nonnegative.
-   */
+  /// Constructs a LinePointConstraint.
+  ///
+  /// @param robot_point Robot point.
+  /// @param field_point Field point.
+  /// @param min_distance Minimum distance between robot line and field point.
+  ///     Must be nonnegative.
   explicit PointPointMinConstraint(Translation2d robot_point,
                                    Translation2d field_point,
                                    double min_distance)
@@ -39,16 +35,14 @@ class TRAJOPT_DLLEXPORT PointPointMinConstraint {
     assert(min_distance >= 0.0);
   }
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/pose_equality_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/pose_equality_constraint.hpp
@@ -11,31 +11,25 @@
 
 namespace trajopt {
 
-/**
- * Pose equality constraint.
- */
+/// Pose equality constraint.
 class TRAJOPT_DLLEXPORT PoseEqualityConstraint {
  public:
-  /**
-   * Constructs a PoseEqualityConstraint.
-   *
-   * @param x The robot's x position.
-   * @param y The robot's y position.
-   * @param heading The robot's heading.
-   */
+  /// Constructs a PoseEqualityConstraint.
+  ///
+  /// @param x The robot's x position.
+  /// @param y The robot's y position.
+  /// @param heading The robot's heading.
   PoseEqualityConstraint(double x, double y, double heading)
       : m_pose{x, y, heading} {}
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/constraint/translation_equality_constraint.hpp
+++ b/trajoptlib/include/trajopt/constraint/translation_equality_constraint.hpp
@@ -11,29 +11,23 @@
 
 namespace trajopt {
 
-/**
- * Translation equality constraint.
- */
+/// Translation equality constraint.
 class TRAJOPT_DLLEXPORT TranslationEqualityConstraint {
  public:
-  /**
-   * Constructs a TranslationEqualityConstraint.
-   *
-   * @param x The robot's x position.
-   * @param y The robot's y position.
-   */
+  /// Constructs a TranslationEqualityConstraint.
+  ///
+  /// @param x The robot's x position.
+  /// @param y The robot's y position.
   TranslationEqualityConstraint(double x, double y) : m_translation{x, y} {}
 
-  /**
-   * Applies this constraint to the given problem.
-   *
-   * @param problem The optimization problem.
-   * @param pose The robot's pose.
-   * @param linear_velocity The robot's linear velocity.
-   * @param angular_velocity The robot's angular velocity.
-   * @param linear_acceleration The robot's linear acceleration.
-   * @param angular_acceleration The robot's angular acceleration.
-   */
+  /// Applies this constraint to the given problem.
+  ///
+  /// @param problem The optimization problem.
+  /// @param pose The robot's pose.
+  /// @param linear_velocity The robot's linear velocity.
+  /// @param angular_velocity The robot's angular velocity.
+  /// @param linear_acceleration The robot's linear acceleration.
+  /// @param angular_acceleration The robot's angular acceleration.
   void apply(
       slp::Problem<double>& problem, const Pose2v<double>& pose,
       [[maybe_unused]] const Translation2v<double>& linear_velocity,

--- a/trajoptlib/include/trajopt/differential_trajectory_generator.hpp
+++ b/trajoptlib/include/trajopt/differential_trajectory_generator.hpp
@@ -17,9 +17,7 @@
 
 namespace trajopt {
 
-/**
- * A differential drivetrain physical model.
- */
+/// A differential drivetrain physical model.
 struct TRAJOPT_DLLEXPORT DifferentialDrivetrain {
   /// The mass of the robot (kg).
   double mass;
@@ -43,9 +41,7 @@ struct TRAJOPT_DLLEXPORT DifferentialDrivetrain {
   double trackwidth;
 };
 
-/**
- * The holonomic trajectory optimization solution.
- */
+/// The holonomic trajectory optimization solution.
 struct TRAJOPT_DLLEXPORT DifferentialSolution {
   /// Times between samples.
   std::vector<double> dt;
@@ -86,9 +82,7 @@ struct TRAJOPT_DLLEXPORT DifferentialSolution {
   std::vector<double> Fr;
 };
 
-/**
- * Differential trajectory sample.
- */
+/// Differential trajectory sample.
 class TRAJOPT_DLLEXPORT DifferentialTrajectorySample {
  public:
   /// The timestamp.
@@ -129,21 +123,19 @@ class TRAJOPT_DLLEXPORT DifferentialTrajectorySample {
 
   DifferentialTrajectorySample() = default;
 
-  /**
-   * Construct a DifferentialTrajectorySample.
-   *
-   * @param timestamp The timestamp.
-   * @param x The x coordinate. @param y The y coordinate.
-   * @param heading The heading.
-   * @param velocity_l The left wheel velocity.
-   * @param velocity_r The right wheel velocity.
-   * @param angular_velocity The chassis angular velocity.
-   * @param acceleration_l The left wheel acceleration.
-   * @param acceleration_r The right wheel acceleration.
-   * @param angular_acceleration The chassis angular acceleration.
-   * @param force_l The left wheel force.
-   * @param force_r The right wheel force.
-   */
+  /// Construct a DifferentialTrajectorySample.
+  ///
+  /// @param timestamp The timestamp.
+  /// @param x The x coordinate. @param y The y coordinate.
+  /// @param heading The heading.
+  /// @param velocity_l The left wheel velocity.
+  /// @param velocity_r The right wheel velocity.
+  /// @param angular_velocity The chassis angular velocity.
+  /// @param acceleration_l The left wheel acceleration.
+  /// @param acceleration_r The right wheel acceleration.
+  /// @param angular_acceleration The chassis angular acceleration.
+  /// @param force_l The left wheel force.
+  /// @param force_r The right wheel force.
   DifferentialTrajectorySample(double timestamp, double x, double y,
                                double heading, double velocity_l,
                                double velocity_r, double angular_velocity,
@@ -164,9 +156,7 @@ class TRAJOPT_DLLEXPORT DifferentialTrajectorySample {
         force_r{force_r} {}
 };
 
-/**
- * Differential trajectory.
- */
+/// Differential trajectory.
 class TRAJOPT_DLLEXPORT DifferentialTrajectory {
  public:
   /// Trajectory samples.
@@ -174,20 +164,16 @@ class TRAJOPT_DLLEXPORT DifferentialTrajectory {
 
   DifferentialTrajectory() = default;
 
-  /**
-   * Construct a DifferentialTrajectory from samples.
-   *
-   * @param samples The samples.
-   */
+  /// Construct a DifferentialTrajectory from samples.
+  ///
+  /// @param samples The samples.
   explicit DifferentialTrajectory(
       std::vector<DifferentialTrajectorySample> samples)
       : samples{std::move(samples)} {}
 
-  /**
-   * Construct a DifferentialTrajectory from a swerve solution.
-   *
-   * @param solution The swerve solution.
-   */
+  /// Construct a DifferentialTrajectory from a swerve solution.
+  ///
+  /// @param solution The swerve solution.
   explicit DifferentialTrajectory(const DifferentialSolution& solution) {
     double ts = 0.0;
     for (size_t sample = 0; sample < solution.x.size(); ++sample) {
@@ -202,43 +188,33 @@ class TRAJOPT_DLLEXPORT DifferentialTrajectory {
   }
 };
 
-/**
- * A differential drive path.
- */
+/// A differential drive path.
 using DifferentialPath = Path<DifferentialDrivetrain, DifferentialSolution>;
 
-/**
- * Builds a differential drive path using information about how the robot
- * must travel through a series of waypoints. This path can be converted
- * to a trajectory using DifferentialTrajectoryGenerator.
- */
+/// Builds a differential drive path using information about how the robot
+/// must travel through a series of waypoints. This path can be converted
+/// to a trajectory using DifferentialTrajectoryGenerator.
 using DifferentialPathBuilder =
     PathBuilder<DifferentialDrivetrain, DifferentialSolution>;
 
-/**
- * This trajectory generator class contains functions to generate
- * time-optimal trajectories for differential drivetrain types.
- */
+/// This trajectory generator class contains functions to generate
+/// time-optimal trajectories for differential drivetrain types.
 class TRAJOPT_DLLEXPORT DifferentialTrajectoryGenerator {
  public:
-  /**
-   * Construct a new swerve trajectory optimization problem.
-   *
-   * @param path_builder The path builder.
-   * @param handle An identifier for state callbacks.
-   */
+  /// Construct a new swerve trajectory optimization problem.
+  ///
+  /// @param path_builder The path builder.
+  /// @param handle An identifier for state callbacks.
   explicit DifferentialTrajectoryGenerator(DifferentialPathBuilder path_builder,
                                            int64_t handle = 0);
 
-  /**
-   * Generates an optimal trajectory.
-   *
-   * This function may take a long time to complete.
-   *
-   * @param diagnostics Enables diagnostic prints.
-   * @return Returns a differential trajectory on success, or the solver's exit
-   *     status on failure.
-   */
+  /// Generates an optimal trajectory.
+  ///
+  /// This function may take a long time to complete.
+  ///
+  /// @param diagnostics Enables diagnostic prints.
+  /// @return Returns a differential trajectory on success, or the solver's exit
+  ///     status on failure.
   std::expected<DifferentialSolution, slp::ExitStatus> generate(
       bool diagnostics = false);
 

--- a/trajoptlib/include/trajopt/geometry/pose2.hpp
+++ b/trajoptlib/include/trajopt/geometry/pose2.hpp
@@ -13,82 +13,62 @@
 
 namespace trajopt {
 
-/**
- * Represents a 2D pose with translation and rotation.
- */
+/// Represents a 2D pose with translation and rotation.
 template <typename T>
 class Pose2 {
  public:
-  /**
-   * Constructs a pose at the origin facing toward the positive x-axis.
-   */
+  /// Constructs a pose at the origin facing toward the positive x-axis.
   constexpr Pose2() = default;
 
-  /**
-   * Constructs a pose with the specified translation and rotation.
-   *
-   * @param translation The translational component of the pose.
-   * @param rotation The rotational component of the pose.
-   */
+  /// Constructs a pose with the specified translation and rotation.
+  ///
+  /// @param translation The translational component of the pose.
+  /// @param rotation The rotational component of the pose.
   constexpr Pose2(Translation2<T> translation, Rotation2<T> rotation)
       : m_translation{std::move(translation)},
         m_rotation{std::move(rotation)} {}
 
-  /**
-   * Constructs a pose with x and y translations instead of a separate
-   * translation.
-   *
-   * @param x The x component of the translational component of the pose.
-   * @param y The y component of the translational component of the pose.
-   * @param rotation The rotational component of the pose.
-   */
+  /// Constructs a pose with x and y translations instead of a separate
+  /// translation.
+  ///
+  /// @param x The x component of the translational component of the pose.
+  /// @param y The y component of the translational component of the pose.
+  /// @param rotation The rotational component of the pose.
   constexpr Pose2(T x, T y, Rotation2<T> rotation)
       : m_translation{Translation2<T>{std::move(x), std::move(y)}},
         m_rotation{std::move(rotation)} {}
 
-  /**
-   * Coerces one pose type into another.
-   *
-   * @param other The other pose type.
-   */
+  /// Coerces one pose type into another.
+  ///
+  /// @param other The other pose type.
   template <typename U>
   constexpr explicit Pose2(const Pose2<U>& other)
       : m_translation{other.translation()}, m_rotation{other.rotation()} {}
 
-  /**
-   * Returns the underlying translation.
-   *
-   * @return Reference to the translational component of the pose.
-   */
+  /// Returns the underlying translation.
+  ///
+  /// @return Reference to the translational component of the pose.
   constexpr const Translation2<T>& translation() const { return m_translation; }
 
-  /**
-   * Returns the X component of the pose's translation.
-   *
-   * @return The x component of the pose's translation.
-   */
+  /// Returns the X component of the pose's translation.
+  ///
+  /// @return The x component of the pose's translation.
   constexpr const T& x() const { return m_translation.x(); }
 
-  /**
-   * Returns the Y component of the pose's translation.
-   *
-   * @return The y component of the pose's translation.
-   */
+  /// Returns the Y component of the pose's translation.
+  ///
+  /// @return The y component of the pose's translation.
   constexpr const T& y() const { return m_translation.y(); }
 
-  /**
-   * Returns the underlying rotation.
-   *
-   * @return Reference to the rotational component of the pose.
-   */
+  /// Returns the underlying rotation.
+  ///
+  /// @return Reference to the rotational component of the pose.
   constexpr const Rotation2<T>& rotation() const { return m_rotation; }
 
-  /**
-   * Rotates the pose around the origin and returns the new pose.
-   *
-   * @param rotation The rotation to transform the pose by.
-   * @return The rotated pose.
-   */
+  /// Rotates the pose around the origin and returns the new pose.
+  ///
+  /// @param rotation The rotation to transform the pose by.
+  /// @return The rotated pose.
   constexpr Pose2<T> rotate_by(const Rotation2<T>& rotation) const {
     return {m_translation.rotate_by(rotation), m_rotation.rotate_by(rotation)};
   }

--- a/trajoptlib/include/trajopt/geometry/rotation2.hpp
+++ b/trajoptlib/include/trajopt/geometry/rotation2.hpp
@@ -13,23 +13,17 @@
 
 namespace trajopt {
 
-/**
- * A rotation in a 2D coordinate frame represented by a point on the unit circle
- * (cosine and sine).
- */
+/// A rotation in a 2D coordinate frame represented by a point on the unit
+/// circle (cosine and sine).
 template <typename T>
 class Rotation2 {
  public:
-  /**
-   * Constructs a rotation with a default angle of 0 degrees.
-   */
+  /// Constructs a rotation with a default angle of 0 degrees.
   constexpr Rotation2() = default;
 
-  /**
-   * Constructs a rotation with the given angle.
-   *
-   * @param angle The angle in radians.
-   */
+  /// Constructs a rotation with the given angle.
+  ///
+  /// @param angle The angle in radians.
   // NOLINTNEXTLINE (google-explicit-constructor)
   constexpr Rotation2(const T& angle) {
     using std::cos;
@@ -39,23 +33,19 @@ class Rotation2 {
     m_sin = sin(angle);
   }
 
-  /**
-   * Constructs a rotation with the given cosine and sine components.
-   *
-   * @param cos The cosine component of the rotation.
-   * @param sin The sine component of the rotation.
-   */
+  /// Constructs a rotation with the given cosine and sine components.
+  ///
+  /// @param cos The cosine component of the rotation.
+  /// @param sin The sine component of the rotation.
   constexpr Rotation2(T cos, T sin)
     requires(!std::same_as<T, double>)
       : m_cos{std::move(cos)}, m_sin{std::move(sin)} {}
 
-  /**
-   * Constructs a rotation with the given x and y components. The x and y don't
-   * have to be normalized.
-   *
-   * @param x The x component of the rotation.
-   * @param y The y component of the rotation.
-   */
+  /// Constructs a rotation with the given x and y components. The x and y don't
+  /// have to be normalized.
+  ///
+  /// @param x The x component of the rotation.
+  /// @param y The y component of the rotation.
   constexpr Rotation2(double x, double y)
     requires std::same_as<T, double>
   {
@@ -69,53 +59,43 @@ class Rotation2 {
     }
   }
 
-  /**
-   * Coerces one rotation type into another.
-   *
-   * @param other The other rotation type.
-   */
+  /// Coerces one rotation type into another.
+  ///
+  /// @param other The other rotation type.
   template <typename U>
   constexpr explicit Rotation2(const Rotation2<U>& other)
       : m_cos{other.cos()}, m_sin{other.sin()} {}
 
-  /**
-   * Adds two rotations together, with the result being bounded between -pi and
-   * pi.
-   *
-   * @param other The rotation to add.
-   * @return The sum of the two rotations.
-   */
+  /// Adds two rotations together, with the result being bounded between -pi and
+  /// pi.
+  ///
+  /// @param other The rotation to add.
+  /// @return The sum of the two rotations.
   constexpr Rotation2<T> operator+(const Rotation2<T>& other) const {
     return rotate_by(other);
   }
 
-  /**
-   * Subtracts the new rotation from the current rotation and returns the new
-   * rotation.
-   *
-   * @param other The rotation to subtract.
-   * @return The difference between the two rotations.
-   */
+  /// Subtracts the new rotation from the current rotation and returns the new
+  /// rotation.
+  ///
+  /// @param other The rotation to subtract.
+  /// @return The difference between the two rotations.
   constexpr Rotation2<T> operator-(const Rotation2<T>& other) const {
     return *this + -other;
   }
 
-  /**
-   * Takes the inverse of the current rotation.
-   *
-   * @return The inverse of the current rotation.
-   */
+  /// Takes the inverse of the current rotation.
+  ///
+  /// @return The inverse of the current rotation.
   constexpr Rotation2<T> operator-() const {
     return Rotation2<T>{m_cos, -m_sin};
   }
 
-  /**
-   * Adds the new rotation to the current rotation using a clockwise rotation
-   * matrix.
-   *
-   * @param other The rotation to rotate by.
-   * @return The new rotated rotation.
-   */
+  /// Adds the new rotation to the current rotation using a clockwise rotation
+  /// matrix.
+  ///
+  /// @param other The rotation to rotate by.
+  /// @return The new rotated rotation.
   template <typename U>
   constexpr Rotation2<U> rotate_by(const Rotation2<U>& other) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
@@ -123,34 +103,26 @@ class Rotation2 {
                         cos() * other.sin() + sin() * other.cos()};
   }
 
-  /**
-   * Returns the rotation as an Euler angle in radians.
-   *
-   * @return The Euler angle in radians.
-   */
+  /// Returns the rotation as an Euler angle in radians.
+  ///
+  /// @return The Euler angle in radians.
   constexpr T radians() const { return atan2(m_sin, m_cos); }
 
-  /**
-   * Returns the rotation as an Euler angle in degrees.
-   *
-   * @return The Euler angle in degrees.
-   */
+  /// Returns the rotation as an Euler angle in degrees.
+  ///
+  /// @return The Euler angle in degrees.
   constexpr T degrees() const {
     return atan2(m_sin, m_cos) / std::numbers::pi * 180.0;
   }
 
-  /**
-   * Returns the cosine of the rotation.
-   *
-   * @return The cosine of the rotation.
-   */
+  /// Returns the cosine of the rotation.
+  ///
+  /// @return The cosine of the rotation.
   constexpr const T& cos() const { return m_cos; }
 
-  /**
-   * Returns the sine of the rotation.
-   *
-   * @return The sine of the rotation.
-   */
+  /// Returns the sine of the rotation.
+  ///
+  /// @return The sine of the rotation.
   constexpr const T& sin() const { return m_sin; }
 
  private:

--- a/trajoptlib/include/trajopt/geometry/translation2.hpp
+++ b/trajoptlib/include/trajopt/geometry/translation2.hpp
@@ -14,128 +14,103 @@
 
 namespace trajopt {
 
-/**
- * Represents a translation in 2D space.
- */
+/// Represents a translation in 2D space.
 template <typename T>
 class Translation2 {
  public:
-  /**
-   * Constructs a translation with x and y components equal to zero.
-   */
+  /// Constructs a translation with x and y components equal to zero.
   constexpr Translation2() = default;
 
-  /**
-   * Constructs a translation with the given x and y components.
-   *
-   * @param x The x component of the translation.
-   * @param y The y component of the translation.
-   */
+  /// Constructs a translation with the given x and y components.
+  ///
+  /// @param x The x component of the translation.
+  /// @param y The y component of the translation.
   template <typename X, typename Y>
   constexpr Translation2(X x, Y y) : m_x{std::move(x)}, m_y{std::move(y)} {}
 
-  /**
-   * Constructs a translation with the provided distance and angle.
-   *
-   * This is essentially converting from polar coordinates to Cartesian
-   * coordinates.
-   *
-   * @param distance The distance from the origin to the end of the translation.
-   * @param angle The angle between the x-axis and the translation vector.
-   */
+  /// Constructs a translation with the provided distance and angle.
+  ///
+  /// This is essentially converting from polar coordinates to Cartesian
+  /// coordinates.
+  ///
+  /// @param distance The distance from the origin to the end of the
+  ///     translation.
+  /// @param angle The angle between the x-axis and the translation vector.
   template <typename U>
   constexpr Translation2(T distance, const Rotation2<U>& angle)
       : m_x{distance * angle.cos()}, m_y{distance * angle.sin()} {}
 
-  /**
-   * Coerces one translation type into another.
-   *
-   * @param other The other translation type.
-   */
+  /// Coerces one translation type into another.
+  ///
+  /// @param other The other translation type.
   template <typename U>
   constexpr explicit Translation2(const Translation2<U>& other)
       : m_x{other.m_x}, m_y{other.m_y} {}
 
-  /**
-   * Returns the x component of the translation.
-   *
-   * @return The x component of the translation.
-   */
+  /// Returns the x component of the translation.
+  ///
+  /// @return The x component of the translation.
   constexpr const T& x() const { return m_x; }
 
-  /**
-   * Returns the y component of the translation.
-   *
-   * @return The y component of the translation.
-   */
+  /// Returns the y component of the translation.
+  ///
+  /// @return The y component of the translation.
   constexpr const T& y() const { return m_y; }
 
-  /**
-   * Returns the sum of two translations in 2D space.
-   *
-   * @param other The translation to add.
-   *
-   * @return The sum of the translations.
-   */
+  /// Returns the sum of two translations in 2D space.
+  ///
+  /// @param other The translation to add.
+  ///
+  /// @return The sum of the translations.
   template <typename U>
   constexpr auto operator+(const Translation2<U>& other) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
     return Translation2<R>{x() + other.x(), y() + other.y()};
   }
 
-  /**
-   * Returns the difference between two translations.
-   *
-   * @param other The translation to subtract.
-   * @return The difference between the two translations.
-   */
+  /// Returns the difference between two translations.
+  ///
+  /// @param other The translation to subtract.
+  /// @return The difference between the two translations.
   template <typename U>
   constexpr auto operator-(const Translation2<U>& other) const {
     return *this + -other;
   }
 
-  /**
-   * Returns the inverse of the current translation.
-   *
-   * This is equivalent to rotating by 180 degrees, flipping the point over both
-   * axes, or negating all components of the translation.
-   *
-   * @return The inverse of the current translation.
-   */
+  /// Returns the inverse of the current translation.
+  ///
+  /// This is equivalent to rotating by 180 degrees, flipping the point over
+  /// both axes, or negating all components of the translation.
+  ///
+  /// @return The inverse of the current translation.
   constexpr Translation2<T> operator-() const { return {-m_x, -m_y}; }
 
-  /**
-   * Returns the translation multiplied by a scalar.
-   *
-   * @param scalar The scalar to multiply by.
-   *
-   * @return The scaled translation.
-   */
+  /// Returns the translation multiplied by a scalar.
+  ///
+  /// @param scalar The scalar to multiply by.
+  ///
+  /// @return The scaled translation.
   template <typename U>
   constexpr auto operator*(const U& scalar) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
     return Translation2<R>{m_x * scalar, m_y * scalar};
   }
 
-  /**
-   * Returns the translation divided by a scalar.
-   *
-   * @param scalar The scalar to divide by.
-   *
-   * @return The scaled translation.
-   */
+  /// Returns the translation divided by a scalar.
+  ///
+  /// @param scalar The scalar to divide by.
+  ///
+  /// @return The scaled translation.
   template <typename U>
   constexpr auto operator/(const U& scalar) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
     return Translation2<R>{m_x / scalar, m_y / scalar};
   }
 
-  /**
-   * Applies a rotation to the translation in 2D space.
-   *
-   * @param rotation The rotation to rotate the translation by.
-   * @return The new rotated translation.
-   */
+  /// Applies a rotation to the translation in 2D space.
+  ///
+  /// @param rotation The rotation to rotate the translation by.
+  /// @return The new rotated translation.
   template <typename U>
   constexpr auto rotate_by(const Rotation2<U>& rotation) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
@@ -143,61 +118,49 @@ class Translation2 {
                            m_x * rotation.sin() + m_y * rotation.cos()};
   }
 
-  /**
-   * Returns the angle this translation forms with the positive x-axis.
-   *
-   * @return The angle of the translation.
-   */
+  /// Returns the angle this translation forms with the positive x-axis.
+  ///
+  /// @return The angle of the translation.
   constexpr Rotation2<T> angle() const { return Rotation2<T>{m_x, m_y}; }
 
-  /**
-   * Returns the dot product between two translations.
-   *
-   * @param other The other translation.
-   * @return The dot product.
-   */
+  /// Returns the dot product between two translations.
+  ///
+  /// @param other The other translation.
+  /// @return The dot product.
   template <typename U>
   constexpr auto dot(const Translation2<U>& other) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
     return R{m_x * other.x() + m_y * other.y()};
   }
 
-  /**
-   * Returns the cross product between two translations.
-   *
-   * @param other The other translation.
-   * @return The cross product.
-   */
+  /// Returns the cross product between two translations.
+  ///
+  /// @param other The other translation.
+  /// @return The cross product.
   template <typename U>
   constexpr auto cross(const Translation2<U>& other) const {
     using R = decltype(std::declval<T>() + std::declval<U>());
     return R{m_x * other.y() - m_y * other.x()};
   }
 
-  /**
-   * Returns the norm of the translation. This is the distance from the origin
-   * to the translation.
-   *
-   * @return The norm of the translation.
-   */
+  /// Returns the norm of the translation. This is the distance from the origin
+  /// to the translation.
+  ///
+  /// @return The norm of the translation.
   constexpr auto norm() const { return hypot(m_x, m_y); }
 
-  /**
-   * Returns the squared norm of the translation. This is the sum of squares of
-   * the translation's components.
-   *
-   * @return The squared norm of the translation.
-   */
+  /// Returns the squared norm of the translation. This is the sum of squares of
+  /// the translation's components.
+  ///
+  /// @return The squared norm of the translation.
   constexpr auto squared_norm() const { return m_x * m_x + m_y * m_y; }
 
-  /**
-   * Returns the distance between two translations in 2D space.
-   *
-   * The distance between translations is defined as √((x₂−x₁)²+(y₂−y₁)²).
-   *
-   * @param other The translation to which to compute the distance.
-   * @return The distance between the two translations.
-   */
+  /// Returns the distance between two translations in 2D space.
+  ///
+  /// The distance between translations is defined as √((x₂−x₁)²+(y₂−y₁)²).
+  ///
+  /// @param other The translation to which to compute the distance.
+  /// @return The distance between the two translations.
   template <typename U>
   constexpr auto distance(const Translation2<U>& other) const {
     return hypot(other.x() - m_x, other.y() - m_y);
@@ -257,34 +220,24 @@ inline bool operator==(const Translation2d& lhs, const Translation2d& rhs) {
 
 namespace std {
 
-/**
- * tuple_size specialization for translations. Used for structured bindings.
- */
+/// tuple_size specialization for translations. Used for structured bindings.
 template <typename T>
 struct tuple_size<trajopt::Translation2<T>>
     : std::integral_constant<size_t, 2> {};
 
-/**
- * tuple_element specialization for first element of translation. Used for
- * structured bindings.
- */
+/// tuple_element specialization for first element of translation. Used for
+/// structured bindings.
 template <typename T>
 struct tuple_element<0, trajopt::Translation2<T>> {
-  /**
-   * tuple_element typedef for first element of translation.
-   */
+  /// tuple_element typedef for first element of translation.
   using type = T;
 };
 
-/**
- * Tuple element specialization for second element of translation. Used for
- * structured bindings.
- */
+/// Tuple element specialization for second element of translation. Used for
+/// structured bindings.
 template <typename T>
 struct tuple_element<1, trajopt::Translation2<T>> {
-  /**
-   * Tuple element typedef for first element of translation.
-   */
+  /// Tuple element typedef for first element of translation.
   using type = T;
 };
 

--- a/trajoptlib/include/trajopt/path/path.hpp
+++ b/trajoptlib/include/trajopt/path/path.hpp
@@ -12,9 +12,7 @@
 
 namespace trajopt {
 
-/**
- * A path waypoint.
- */
+/// A path waypoint.
 struct TRAJOPT_DLLEXPORT Waypoint {
   /// Instantaneous constraints at the waypoint.
   std::vector<Constraint> waypoint_constraints;
@@ -23,12 +21,10 @@ struct TRAJOPT_DLLEXPORT Waypoint {
   std::vector<Constraint> segment_constraints;
 };
 
-/**
- * A path.
- *
- * @tparam Drivetrain The drivetrain type (e.g., swerve, differential).
- * @tparam Solution The solution type (e.g., swerve, differential).
- */
+/// A path.
+///
+/// @tparam Drivetrain The drivetrain type (e.g., swerve, differential).
+/// @tparam Solution The solution type (e.g., swerve, differential).
 template <typename Drivetrain, typename Solution>
 struct TRAJOPT_DLLEXPORT Path {
   /// Waypoints along the path.

--- a/trajoptlib/include/trajopt/path/path_builder.hpp
+++ b/trajoptlib/include/trajopt/path/path_builder.hpp
@@ -18,13 +18,11 @@
 
 namespace trajopt {
 
-/**
- * Represents a physical keep-out region that the robot must avoid by a certain
- * distance. Arbitrary polygons can be expressed with this class, and keep-out
- * circles can also be created by only using one point with a safety distance.
- *
- * Keep-out points must be wound either clockwise or counterclockwise.
- */
+/// Represents a physical keep-out region that the robot must avoid by a certain
+/// distance. Arbitrary polygons can be expressed with this class, and keep-out
+/// circles can also be created by only using one point with a safety distance.
+///
+/// Keep-out points must be wound either clockwise or counterclockwise.
 struct TRAJOPT_DLLEXPORT KeepOutRegion {
   /// Minimum distance from the keep-out region the robot must maintain.
   double safety_distance;
@@ -33,33 +31,27 @@ struct TRAJOPT_DLLEXPORT KeepOutRegion {
   std::vector<Translation2d> points;
 };
 
-/**
- * Path builder.
- *
- * @tparam Drivetrain The drivetrain type (e.g., swerve, differential).
- * @tparam Solution The solution type (e.g., swerve, differential).
- */
+/// Path builder.
+///
+/// @tparam Drivetrain The drivetrain type (e.g., swerve, differential).
+/// @tparam Solution The solution type (e.g., swerve, differential).
 template <typename Drivetrain, typename Solution>
 class TRAJOPT_DLLEXPORT PathBuilder {
  public:
-  /**
-   * Set the Drivetrain object
-   *
-   * @param drivetrain the new drivetrain
-   */
+  /// Set the Drivetrain object
+  ///
+  /// @param drivetrain the new drivetrain
   void set_drivetrain(Drivetrain drivetrain) {
     path.drivetrain = std::move(drivetrain);
   }
 
-  /**
-   * Add a rectangular bumper to a list used when applying
-   * keep-out constraints.
-   *
-   * @param front Distance in meters from center to front bumper edge
-   * @param left Distance in meters from center to left bumper edge
-   * @param right Distance in meters from center to right bumper edge
-   * @param back Distance in meters from center to back bumper edge
-   */
+  /// Add a rectangular bumper to a list used when applying
+  /// keep-out constraints.
+  ///
+  /// @param front Distance in meters from center to front bumper edge
+  /// @param left Distance in meters from center to left bumper edge
+  /// @param right Distance in meters from center to right bumper edge
+  /// @param back Distance in meters from center to back bumper edge
   void set_bumpers(double front, double left, double right, double back) {
     bumpers.emplace_back(trajopt::KeepOutRegion{.safety_distance = 0.01,
                                                 .points = {{+front, +left},
@@ -68,55 +60,45 @@ class TRAJOPT_DLLEXPORT PathBuilder {
                                                            {+front, -right}}});
   }
 
-  /**
-   * Get all bumpers currently added to the path builder
-   *
-   * @return a list of bumpers applied to the builder.
-   */
+  /// Get all bumpers currently added to the path builder
+  ///
+  /// @return a list of bumpers applied to the builder.
   std::vector<KeepOutRegion>& get_bumpers() { return bumpers; }
 
-  /**
-   * If using a discrete algorithm, specify the number of discrete
-   * samples for every segment of the trajectory
-   *
-   * @param counts the sequence of control interval counts per segment, length
-   * is number of waypoints - 1
-   */
+  /// If using a discrete algorithm, specify the number of discrete
+  /// samples for every segment of the trajectory
+  ///
+  /// @param counts the sequence of control interval counts per segment, length
+  ///     is number of waypoints - 1
   void set_control_interval_counts(std::vector<size_t>&& counts) {
     control_interval_counts = std::move(counts);
   }
 
-  /**
-   * Get the Control Interval Counts object
-   *
-   * @return const std::vector<size_t>&
-   */
+  /// Get the Control Interval Counts object
+  ///
+  /// @return const std::vector<size_t>&
   const std::vector<size_t>& get_control_interval_counts() const {
     return control_interval_counts;
   }
 
-  /**
-   * Provide a guess of the instantaneous pose of the robot at a waypoint.
-   *
-   * @param wpt_index the waypoint to apply the guess to
-   * @param pose_guess the guess of the robot's pose
-   */
+  /// Provide a guess of the instantaneous pose of the robot at a waypoint.
+  ///
+  /// @param wpt_index the waypoint to apply the guess to
+  /// @param pose_guess the guess of the robot's pose
   void wpt_initial_guess_point(size_t wpt_index, const Pose2d& pose_guess) {
     new_wpts(wpt_index);
     initial_guess_points.at(wpt_index).back() = pose_guess;
   }
 
-  /**
-   * Add a sequence of initial guess points between two waypoints. The points
-   * are inserted between the waypoints at fromIndex and fromIndex + 1. Linear
-   * interpolation between the waypoint initial guess points and these segment
-   * initial guess points is used as the initial guess of the robot's pose over
-   * the trajectory.
-   *
-   * @param from_index index of the waypoint the initial guess point
-   *                   comes immediately after
-   * @param sgmt_pose_guess the sequence of initial guess points
-   */
+  /// Add a sequence of initial guess points between two waypoints. The points
+  /// are inserted between the waypoints at fromIndex and fromIndex + 1. Linear
+  /// interpolation between the waypoint initial guess points and these segment
+  /// initial guess points is used as the initial guess of the robot's pose over
+  /// the trajectory.
+  ///
+  /// @param from_index index of the waypoint the initial guess point comes
+  ///     immediately after
+  /// @param sgmt_pose_guess the sequence of initial guess points
   void sgmt_initial_guess_points(size_t from_index,
                                  const std::vector<Pose2d>& sgmt_pose_guess) {
     new_wpts(from_index + 1);
@@ -127,57 +109,49 @@ class TRAJOPT_DLLEXPORT PathBuilder {
                                    sgmt_pose_guess.end());
   }
 
-  /**
-   * Create a pose waypoint constraint on the waypoint at the provided
-   * index, and add an initial guess with the same pose This specifies that the
-   * position and heading of the robot at the waypoint must be fixed at the
-   * values provided.
-   *
-   * @param index index of the pose waypoint
-   * @param x the x
-   * @param y the y
-   * @param heading the heading
-   */
+  /// Create a pose waypoint constraint on the waypoint at the provided
+  /// index, and add an initial guess with the same pose This specifies that the
+  /// position and heading of the robot at the waypoint must be fixed at the
+  /// values provided.
+  ///
+  /// @param index index of the pose waypoint
+  /// @param x the x
+  /// @param y the y
+  /// @param heading the heading
   void pose_wpt(size_t index, double x, double y, double heading) {
     wpt_constraint(index, PoseEqualityConstraint{x, y, heading});
     wpt_initial_guess_point(index, {x, y, {heading}});
   }
 
-  /**
-   * Create a translation waypoint constraint on the waypoint at the
-   * provided index, and add an initial guess point with the same translation.
-   * This specifies that the position of the robot at the waypoint must be fixed
-   * at the value provided.
-   *
-   * @param index index of the pose waypoint
-   * @param x the x
-   * @param y the y
-   * @param heading_guess optionally, an initial guess of the heading
-   */
+  /// Create a translation waypoint constraint on the waypoint at the
+  /// provided index, and add an initial guess point with the same translation.
+  /// This specifies that the position of the robot at the waypoint must be
+  /// fixed at the value provided.
+  ///
+  /// @param index index of the pose waypoint
+  /// @param x the x
+  /// @param y the y
+  /// @param heading_guess optionally, an initial guess of the heading
   void translation_wpt(size_t index, double x, double y,
                        double heading_guess = 0.0) {
     wpt_constraint(index, TranslationEqualityConstraint{x, y});
     wpt_initial_guess_point(index, {x, y, {heading_guess}});
   }
 
-  /**
-   * Apply a constraint at a waypoint.
-   *
-   * @param index Index of the waypoint.
-   * @param constraint The constraint.
-   */
+  /// Apply a constraint at a waypoint.
+  ///
+  /// @param index Index of the waypoint.
+  /// @param constraint The constraint.
   void wpt_constraint(size_t index, const Constraint& constraint) {
     new_wpts(index);
     path.waypoints.at(index).waypoint_constraints.push_back(constraint);
   }
 
-  /**
-   * Apply a custom constraint to the continuum of state between two waypoints.
-   *
-   * @param from_index Index of the waypoint at the beginning of the continuum.
-   * @param to_index Index of the waypoint at the end of the continuum.
-   * @param constraint The constraint.
-   */
+  /// Apply a custom constraint to the continuum of state between two waypoints.
+  ///
+  /// @param from_index Index of the waypoint at the beginning of the continuum.
+  /// @param to_index Index of the waypoint at the end of the continuum.
+  /// @param constraint The constraint.
   void sgmt_constraint(size_t from_index, size_t to_index,
                        const Constraint& constraint) {
     assert(from_index < to_index);
@@ -190,46 +164,37 @@ class TRAJOPT_DLLEXPORT PathBuilder {
     }
   }
 
-  /**
-   * Add a callback to retrieve the state of the solver as a Solution.
-   *
-   * This callback will run on every iteration of the solver.
-   *
-   * @param callback A callback whose first parameter is the Solution based on
-   *     the solver's state at that iteration, and second parameter is the
-   *     handle passed into Generate().
-   *
-   */
+  /// Add a callback to retrieve the state of the solver as a Solution.
+  ///
+  /// This callback will run on every iteration of the solver.
+  ///
+  /// @param callback A callback whose first parameter is the Solution based on
+  ///     the solver's state at that iteration, and second parameter is the
+  ///     handle passed into Generate().
   void add_callback(
       const std::function<void(const Solution& solution, int64_t handle)>
           callback) {
     path.callbacks.push_back(callback);
   }
 
-  /**
-   * Get the DifferentialPath being constructed
-   *
-   * @return the path
-   */
+  /// Get the DifferentialPath being constructed
+  ///
+  /// @return the path
   Path<Drivetrain, Solution>& get_path() { return path; }
 
-  /**
-   * Calculate a discrete, linear initial guess of the x, y, and heading
-   * of the robot that goes through each segment.
-   *
-   * @return the initial guess, as a solution
-   */
+  /// Calculate a discrete, linear initial guess of the x, y, and heading of the
+  /// robot that goes through each segment.
+  ///
+  /// @return the initial guess, as a solution
   Solution calculate_linear_initial_guess() const {
     return generate_linear_initial_guess<Solution>(initial_guess_points,
                                                    control_interval_counts);
   }
 
-  /**
-   * Calculate a discrete, spline initial guess of the x, y, and heading of the
-   * robot that goes through each segment.
-   *
-   * @return the initial guess, as a solution
-   */
+  /// Calculate a discrete, spline initial guess of the x, y, and heading of the
+  /// robot that goes through each segment.
+  ///
+  /// @return the initial guess, as a solution
   Solution calculate_spline_initial_guess() const {
     return generate_spline_initial_guess<Solution>(initial_guess_points,
                                                    control_interval_counts);
@@ -248,11 +213,9 @@ class TRAJOPT_DLLEXPORT PathBuilder {
   /// The control interval counts.
   std::vector<size_t> control_interval_counts;
 
-  /**
-   * Add new waypoints up to and including the given index.
-   *
-   * @param final_index The final index.
-   */
+  /// Add new waypoints up to and including the given index.
+  ///
+  /// @param final_index The final index.
   void new_wpts(size_t final_index) {
     if (final_index < path.waypoints.size()) {
       return;

--- a/trajoptlib/include/trajopt/spline/cubic_hermite_pose_spline_holonomic.hpp
+++ b/trajoptlib/include/trajopt/spline/cubic_hermite_pose_spline_holonomic.hpp
@@ -14,29 +14,25 @@
 
 namespace trajopt {
 
-/**
- * Represents a cubic pose spline, which is a specific implementation of a cubic
- * hermite spline.
- */
+/// Represents a cubic pose spline, which is a specific implementation of a
+/// cubic hermite spline.
 class TRAJOPT_DLLEXPORT CubicHermitePoseSplineHolonomic : CubicHermiteSpline {
  public:
   /// Pose2d with curvature.
   using PoseWithCurvature = std::pair<Pose2d, double>;
 
-  /**
-   * Constructs a cubic pose spline.
-   *
-   * @param x_initial_control_vector The control vector for the initial point in
-   *     the x dimension.
-   * @param x_final_control_vector The control vector for the final point in
-   *     the x dimension.
-   * @param y_initial_control_vector The control vector for the initial point in
-   *     the y dimension.
-   * @param y_final_control_vector The control vector for the final point in
-   *     the y dimension.
-   * @param r0 Initial heading.
-   * @param r1 Final heading.
-   */
+  /// Constructs a cubic pose spline.
+  ///
+  /// @param x_initial_control_vector The control vector for the initial point
+  ///     in the x dimension.
+  /// @param x_final_control_vector The control vector for the final point in
+  ///     the x dimension.
+  /// @param y_initial_control_vector The control vector for the initial point
+  ///     in the y dimension.
+  /// @param y_final_control_vector The control vector for the final point in
+  ///     the y dimension.
+  /// @param r0 Initial heading.
+  /// @param r1 Final heading.
   CubicHermitePoseSplineHolonomic(
       std::array<double, 2> x_initial_control_vector,
       std::array<double, 2> x_final_control_vector,
@@ -48,43 +44,35 @@ class TRAJOPT_DLLEXPORT CubicHermitePoseSplineHolonomic : CubicHermiteSpline {
         r0(r0),
         theta(0.0, (-r0).rotate_by(r1).radians(), 0, 0) {}
 
-  /**
-   * Return course at point t.
-   *
-   * @param t The point t
-   * @return The course at point t.
-   */
+  /// Return course at point t.
+  ///
+  /// @param t The point t
+  /// @return The course at point t.
   Rotation2d GetCourse(double t) const {
     const PoseWithCurvature spline_point =
         CubicHermiteSpline::get_point(t).value();
     return spline_point.first.rotation();
   }
 
-  /**
-   * Return heading at point t.
-   *
-   * @param t The point t
-   * @return The heading at point t.
-   */
+  /// Return heading at point t.
+  ///
+  /// @param t The point t
+  /// @return The heading at point t.
   Rotation2d get_heading(double t) const {
     return r0.rotate_by(Rotation2d{theta.get_position(t)});
   }
 
-  /**
-   * Return heading rate at point t.
-   *
-   * @param t The point t
-   * @return The heading rate at point t.
-   */
+  /// Return heading rate at point t.
+  ///
+  /// @param t The point t
+  /// @return The heading rate at point t.
   double get_heading_rate(double t) const { return theta.get_velocity(t); }
 
-  /**
-   * Gets the pose and curvature at some point t on the spline.
-   *
-   * @param t The point t
-   * @param is_differential Whether the drivetrain is a differential drive.
-   * @return The pose and curvature at that point.
-   */
+  /// Gets the pose and curvature at some point t on the spline.
+  ///
+  /// @param t The point t
+  /// @param is_differential Whether the drivetrain is a differential drive.
+  /// @return The pose and curvature at that point.
   std::optional<PoseWithCurvature> get_point(double t,
                                              bool is_differential) const {
     if (is_differential) {

--- a/trajoptlib/include/trajopt/spline/cubic_hermite_spline.hpp
+++ b/trajoptlib/include/trajopt/spline/cubic_hermite_spline.hpp
@@ -11,25 +11,21 @@
 
 namespace trajopt {
 
-/**
- * Represents a hermite spline of degree 3.
- */
+/// Represents a hermite spline of degree 3.
 class TRAJOPT_DLLEXPORT CubicHermiteSpline : public Spline<3> {
  public:
-  /**
-   * Constructs a cubic hermite spline with the specified control vectors. Each
-   * control vector contains info about the location of the point and its first
-   * derivative.
-   *
-   * @param x_initial_control_vector The control vector for the initial point in
-   * the x dimension.
-   * @param x_final_control_vector The control vector for the final point in
-   * the x dimension.
-   * @param y_initial_control_vector The control vector for the initial point in
-   * the y dimension.
-   * @param y_final_control_vector The control vector for the final point in
-   * the y dimension.
-   */
+  /// Constructs a cubic hermite spline with the specified control vectors. Each
+  /// control vector contains info about the location of the point and its first
+  /// derivative.
+  ///
+  /// @param x_initial_control_vector The control vector for the initial point
+  ///     in the x dimension.
+  /// @param x_final_control_vector The control vector for the final point in
+  ///     the x dimension.
+  /// @param y_initial_control_vector The control vector for the initial point
+  ///     in the y dimension.
+  /// @param y_final_control_vector The control vector for the final point in
+  ///     the y dimension.
   CubicHermiteSpline(std::array<double, 2> x_initial_control_vector,
                      std::array<double, 2> x_final_control_vector,
                      std::array<double, 2> y_initial_control_vector,
@@ -96,29 +92,23 @@ class TRAJOPT_DLLEXPORT CubicHermiteSpline : public Spline<3> {
     }
   }
 
-  /**
-   * Returns the coefficients matrix.
-   *
-   * @return The coefficients matrix.
-   */
+  /// Returns the coefficients matrix.
+  ///
+  /// @return The coefficients matrix.
   const Eigen::Matrix<double, 6, 3 + 1>& coefficients() const override {
     return m_coefficients;
   }
 
-  /**
-   * Returns the initial control vector that created this spline.
-   *
-   * @return The initial control vector that created this spline.
-   */
+  /// Returns the initial control vector that created this spline.
+  ///
+  /// @return The initial control vector that created this spline.
   const ControlVector& get_initial_control_vector() const override {
     return m_initial_control_vector;
   }
 
-  /**
-   * Returns the final control vector that created this spline.
-   *
-   * @return The final control vector that created this spline.
-   */
+  /// Returns the final control vector that created this spline.
+  ///
+  /// @return The final control vector that created this spline.
   const ControlVector& get_final_control_vector() const override {
     return m_final_control_vector;
   }

--- a/trajoptlib/include/trajopt/spline/cubic_hermite_spline1d.hpp
+++ b/trajoptlib/include/trajopt/spline/cubic_hermite_spline1d.hpp
@@ -6,63 +6,51 @@
 
 namespace trajopt {
 
-/**
- * 1D cubic hermite spline.
- */
+/// 1D cubic hermite spline.
 class TRAJOPT_DLLEXPORT CubicHermiteSpline1d {
  public:
-  /**
-   * Constructs a 1D cubic hermite spline.
-   *
-   * @param p0 The initial position.
-   * @param p1 The final position.
-   * @param v0 The initial velocity.
-   * @param v1 The final velocity.
-   */
+  /// Constructs a 1D cubic hermite spline.
+  ///
+  /// @param p0 The initial position.
+  /// @param p1 The final position.
+  /// @param v0 The initial velocity.
+  /// @param v1 The final velocity.
   constexpr CubicHermiteSpline1d(double p0, double p1, double v0, double v1)
       : a{v0 + v1 + 2 * p0 - 2 * p1},
         b{-2 * v0 - v1 - 3 * p0 + 3 * p1},
         c{v0},
         d{p0} {}
 
-  /**
-   * Return the position at point t.
-   *
-   * @param t The point t
-   * @return The position at point t.
-   */
+  /// Return the position at point t.
+  ///
+  /// @param t The point t
+  /// @return The position at point t.
   constexpr double get_position(double t) const {
     double t2 = t * t;
     double t3 = t2 * t;
     return a * t3 + b * t2 + c * t + d;
   }
 
-  /**
-   * Return the velocity at point t.
-   *
-   * @param t The point t
-   * @return The velocity at point t.
-   */
+  /// Return the velocity at point t.
+  ///
+  /// @param t The point t
+  /// @return The velocity at point t.
   constexpr double get_velocity(double t) const {
     return 3 * a * t * t + 2 * b * t + c;
   }
 
-  /**
-   * Return the acceleration at point t.
-   *
-   * @param t The point t
-   * @return The acceleration at point t.
-   */
+  /// Return the acceleration at point t.
+  ///
+  /// @param t The point t
+  /// @return The acceleration at point t.
   constexpr double get_acceleration(double t) const {
     return 6 * a * t + 2 * b;
   }
 
-  /**
-   * Return the jerk at point t.
-   *
-   * @param t The point t
-   * @return The jerk at point t.
-   */
+  /// Return the jerk at point t.
+  ///
+  /// @param t The point t
+  /// @return The jerk at point t.
   constexpr double get_jerk([[maybe_unused]] double t) const { return 6 * a; }
 
  private:

--- a/trajoptlib/include/trajopt/spline/spline.hpp
+++ b/trajoptlib/include/trajopt/spline/spline.hpp
@@ -12,12 +12,10 @@
 
 namespace trajopt {
 
-/**
- * Represents a two-dimensional parametric spline that interpolates between two
- * points.
- *
- * @tparam Degree The degree of the spline.
- */
+/// Represents a two-dimensional parametric spline that interpolates between two
+/// points.
+///
+/// @tparam Degree The degree of the spline.
 template <int Degree>
 class Spline {
  public:
@@ -26,13 +24,11 @@ class Spline {
 
   virtual ~Spline() = default;
 
-  /**
-   * Represents a control vector for a spline.
-   *
-   * Each element in each array represents the value of the derivative at the
-   * index. For example, the value of x[2] is the second derivative in the x
-   * dimension.
-   */
+  /// Represents a control vector for a spline.
+  ///
+  /// Each element in each array represents the value of the derivative at the
+  /// index. For example, the value of x[2] is the second derivative in the x
+  /// dimension.
   struct ControlVector {
     /// The x components of the control vector.
     std::array<double, (Degree + 1) / 2> x;
@@ -41,12 +37,10 @@ class Spline {
     std::array<double, (Degree + 1) / 2> y;
   };
 
-  /**
-   * Gets the pose and curvature at some point t on the spline.
-   *
-   * @param t The point t
-   * @return The pose and curvature at that point.
-   */
+  /// Gets the pose and curvature at some point t on the spline.
+  ///
+  /// @param t The point t
+  /// @return The pose and curvature at that point.
   std::optional<PoseWithCurvature> get_point(double t) const {
     Eigen::Vector<double, Degree + 1> polynomial_bases;
 
@@ -91,25 +85,19 @@ class Spline {
         curvature};
   }
 
-  /**
-   * Returns the coefficients of the spline.
-   *
-   * @return The coefficients of the spline.
-   */
+  /// Returns the coefficients of the spline.
+  ///
+  /// @return The coefficients of the spline.
   virtual const Eigen::Matrix<double, 6, Degree + 1>& coefficients() const = 0;
 
-  /**
-   * Returns the initial control vector that created this spline.
-   *
-   * @return The initial control vector that created this spline.
-   */
+  /// Returns the initial control vector that created this spline.
+  ///
+  /// @return The initial control vector that created this spline.
   virtual const ControlVector& get_initial_control_vector() const = 0;
 
-  /**
-   * Returns the final control vector that created this spline.
-   *
-   * @return The final control vector that created this spline.
-   */
+  /// Returns the final control vector that created this spline.
+  ///
+  /// @return The final control vector that created this spline.
   virtual const ControlVector& get_final_control_vector() const = 0;
 };
 

--- a/trajoptlib/include/trajopt/spline/spline_helper.hpp
+++ b/trajoptlib/include/trajopt/spline/spline_helper.hpp
@@ -13,21 +13,17 @@
 
 namespace trajopt {
 
-/**
- * Helper class that is used to generate cubic and quintic splines from user
- * provided waypoints.
- */
+/// Helper class that is used to generate cubic and quintic splines from
+/// user-provided waypoints.
 class TRAJOPT_DLLEXPORT SplineHelper {
  public:
-  /**
-   * Returns 2 cubic control vectors from a set of exterior waypoints and
-   * interior translations.
-   *
-   * @param start              The starting pose.
-   * @param interior_waypoints The interior waypoints.
-   * @param end                The ending pose.
-   * @return 2 cubic control vectors.
-   */
+  /// Returns 2 cubic control vectors from a set of exterior waypoints and
+  /// interior translations.
+  ///
+  /// @param start The starting pose.
+  /// @param interior_waypoints The interior waypoints.
+  /// @param end The ending pose.
+  /// @return 2 cubic control vectors.
   static std::array<Spline<3>::ControlVector, 2>
   cubic_control_vectors_from_waypoints(
       const Pose2d& start, const std::vector<Translation2d>& interior_waypoints,
@@ -46,23 +42,20 @@ class TRAJOPT_DLLEXPORT SplineHelper {
     return {initial_control_vector, final_control_vector};
   }
 
-  /**
-   * Returns a set of cubic splines corresponding to the provided control
-   * vectors. The user is free to set the direction of the start and end
-   * point. The directions for the middle waypoints are determined
-   * automatically to ensure continuous curvature throughout the path.
-   *
-   * The derivation for the algorithm used can be found here:
-   * <https://www.uio.no/studier/emner/matnat/ifi/nedlagte-emner/INF-MAT4350/h08/undervisningsmateriale/chap7alecture.pdf>
-   *
-   * @param start The starting control vector.
-   * @param waypoints The middle waypoints. This can be left blank if you
-   * only wish to create a path with two waypoints.
-   * @param end The ending control vector.
-   *
-   * @return A vector of cubic hermite splines that interpolate through the
-   * provided waypoints.
-   */
+  /// Returns a set of cubic splines corresponding to the provided control
+  /// vectors. The user is free to set the direction of the start and end point.
+  /// The directions for the middle waypoints are determined automatically to
+  /// ensure continuous curvature throughout the path.
+  ///
+  /// The derivation for the algorithm used can be found here:
+  /// <https://www.uio.no/studier/emner/matnat/ifi/nedlagte-emner/INF-MAT4350/h08/undervisningsmateriale/chap7alecture.pdf>
+  ///
+  /// @param start The starting control vector.
+  /// @param waypoints The middle waypoints. This can be left blank if you only
+  ///     wish to create a path with two waypoints.
+  /// @param end The ending control vector.
+  /// @return A vector of cubic hermite splines that interpolate through the
+  ///     provided waypoints.
   static std::vector<CubicHermiteSpline> cubic_splines_from_control_vectors(
       const Spline<3>::ControlVector& start,
       std::vector<Translation2d> waypoints,
@@ -173,15 +166,13 @@ class TRAJOPT_DLLEXPORT SplineHelper {
             {point.y(), scalar * point.rotation().sin()}};
   }
 
-  /**
-   * Thomas algorithm for solving tridiagonal systems Af = d.
-   *
-   * @param a the values of A above the diagonal
-   * @param b the values of A on the diagonal
-   * @param c the values of A below the diagonal
-   * @param d the vector on the rhs
-   * @param solution_vector the unknown (solution) vector, modified in-place
-   */
+  /// Thomas algorithm for solving tridiagonal systems Af = d.
+  ///
+  /// @param a the values of A above the diagonal
+  /// @param b the values of A on the diagonal
+  /// @param c the values of A below the diagonal
+  /// @param d the vector on the rhs
+  /// @param solution_vector the unknown (solution) vector, modified in-place
   static void thomas_algorithm(const std::vector<double>& a,
                                const std::vector<double>& b,
                                const std::vector<double>& c,

--- a/trajoptlib/include/trajopt/swerve_trajectory_generator.hpp
+++ b/trajoptlib/include/trajopt/swerve_trajectory_generator.hpp
@@ -16,9 +16,7 @@
 
 namespace trajopt {
 
-/**
- * A swerve drivetrain physical model.
- */
+/// A swerve drivetrain physical model.
 struct TRAJOPT_DLLEXPORT SwerveDrivetrain {
   /// The mass of the robot (kg).
   double mass;
@@ -44,9 +42,7 @@ struct TRAJOPT_DLLEXPORT SwerveDrivetrain {
   std::vector<Translation2d> modules;
 };
 
-/**
- * The swerve drive trajectory optimization solution.
- */
+/// The swerve drive trajectory optimization solution.
 struct TRAJOPT_DLLEXPORT SwerveSolution {
   /// Times between samples.
   std::vector<double> dt;
@@ -88,9 +84,7 @@ struct TRAJOPT_DLLEXPORT SwerveSolution {
   std::vector<std::vector<double>> module_fy;
 };
 
-/**
- * Swerve trajectory sample.
- */
+/// Swerve trajectory sample.
 class TRAJOPT_DLLEXPORT SwerveTrajectorySample {
  public:
   /// The timestamp.
@@ -131,22 +125,20 @@ class TRAJOPT_DLLEXPORT SwerveTrajectorySample {
 
   SwerveTrajectorySample() = default;
 
-  /**
-   * Construct a SwerveTrajectorySample.
-   *
-   * @param timestamp The timestamp.
-   * @param x The x coordinate.
-   * @param y The y coordinate.
-   * @param heading The heading.
-   * @param velocity_x The velocity's x component.
-   * @param velocity_y The velocity's y component.
-   * @param angular_velocity The angular velocity.
-   * @param acceleration_x The acceleration's x component.
-   * @param acceleration_y The acceleration's y component.
-   * @param angular_acceleration The angular acceleration.
-   * @param module_forces_x Forces acting on the modules in the X direction.
-   * @param module_forces_y Forces acting on the modules in the Y direction.
-   */
+  /// Construct a SwerveTrajectorySample.
+  ///
+  /// @param timestamp The timestamp.
+  /// @param x The x coordinate.
+  /// @param y The y coordinate.
+  /// @param heading The heading.
+  /// @param velocity_x The velocity's x component.
+  /// @param velocity_y The velocity's y component.
+  /// @param angular_velocity The angular velocity.
+  /// @param acceleration_x The acceleration's x component.
+  /// @param acceleration_y The acceleration's y component.
+  /// @param angular_acceleration The angular acceleration.
+  /// @param module_forces_x Forces acting on the modules in the X direction.
+  /// @param module_forces_y Forces acting on the modules in the Y direction.
   SwerveTrajectorySample(double timestamp, double x, double y, double heading,
                          double velocity_x, double velocity_y,
                          double angular_velocity, double acceleration_x,
@@ -167,9 +159,7 @@ class TRAJOPT_DLLEXPORT SwerveTrajectorySample {
         module_forces_y{std::move(module_forces_y)} {}
 };
 
-/**
- * Swerve trajectory.
- */
+/// Swerve trajectory.
 class TRAJOPT_DLLEXPORT SwerveTrajectory {
  public:
   /// Trajectory samples.
@@ -177,19 +167,15 @@ class TRAJOPT_DLLEXPORT SwerveTrajectory {
 
   SwerveTrajectory() = default;
 
-  /**
-   * Construct a SwerveTrajectory from samples.
-   *
-   * @param samples The samples.
-   */
+  /// Construct a SwerveTrajectory from samples.
+  ///
+  /// @param samples The samples.
   explicit SwerveTrajectory(std::vector<SwerveTrajectorySample> samples)
       : samples{std::move(samples)} {}
 
-  /**
-   * Construct a SwerveTrajectory from a swerve solution.
-   *
-   * @param solution The swerve solution.
-   */
+  /// Construct a SwerveTrajectory from a swerve solution.
+  ///
+  /// @param solution The swerve solution.
   explicit SwerveTrajectory(const SwerveSolution& solution) {
     double ts = 0.0;
     for (size_t sample = 0; sample < solution.x.size(); ++sample) {
@@ -204,42 +190,32 @@ class TRAJOPT_DLLEXPORT SwerveTrajectory {
   }
 };
 
-/**
- * A swerve path.
- */
+/// A swerve path.
 using SwervePath = Path<SwerveDrivetrain, SwerveSolution>;
 
-/**
- * Builds a swerve path using information about how the robot
- * must travel through a series of waypoints. This path can be converted
- * to a trajectory using SwerveTrajectoryGenerator.
- */
+/// Builds a swerve path using information about how the robot
+/// must travel through a series of waypoints. This path can be converted
+/// to a trajectory using SwerveTrajectoryGenerator.
 using SwervePathBuilder = PathBuilder<SwerveDrivetrain, SwerveSolution>;
 
-/**
- * This trajectory generator class contains functions to generate
- * time-optimal trajectories for several drivetrain types.
- */
+/// This trajectory generator class contains functions to generate
+/// time-optimal trajectories for several drivetrain types.
 class TRAJOPT_DLLEXPORT SwerveTrajectoryGenerator {
  public:
-  /**
-   * Construct a new swerve trajectory optimization problem.
-   *
-   * @param path_builder The path builder.
-   * @param handle An identifier for state callbacks.
-   */
+  /// Construct a new swerve trajectory optimization problem.
+  ///
+  /// @param path_builder The path builder.
+  /// @param handle An identifier for state callbacks.
   explicit SwerveTrajectoryGenerator(SwervePathBuilder path_builder,
                                      int64_t handle = 0);
 
-  /**
-   * Generates an optimal trajectory.
-   *
-   * This function may take a long time to complete.
-   *
-   * @param diagnostics Enables diagnostic prints.
-   * @return Returns a holonomic trajectory on success, or the solver's exit
-   *     status on failure.
-   */
+  /// Generates an optimal trajectory.
+  ///
+  /// This function may take a long time to complete.
+  ///
+  /// @param diagnostics Enables diagnostic prints.
+  /// @return Returns a holonomic trajectory on success, or the solver's exit
+  ///     status on failure.
   std::expected<SwerveSolution, slp::ExitStatus> generate(
       bool diagnostics = false);
 

--- a/trajoptlib/include/trajopt/util/trajopt_util.hpp
+++ b/trajoptlib/include/trajopt/util/trajopt_util.hpp
@@ -9,32 +9,28 @@
 
 namespace trajopt {
 
-/**
- * Get the index of an item in a decision variable array, given the waypoint and
- * sample indices and whether this array includes an entry for the initial
- * sample point ("dt" does not, "x" does).
- *
- * @param N The control interval counts of each segment, in order.
- * @param wpt_index The waypoint index, 0 indexed.
- * @param sample_index The sample index within the segment, 0 indexed.
- * @return The index in the array.
- */
+/// Get the index of an item in a decision variable array, given the waypoint
+/// and sample indices and whether this array includes an entry for the initial
+/// sample point ("dt" does not, "x" does).
+///
+/// @param N The control interval counts of each segment, in order.
+/// @param wpt_index The waypoint index, 0 indexed.
+/// @param sample_index The sample index within the segment, 0 indexed.
+/// @return The index in the array.
 inline size_t get_index(const std::vector<size_t>& N, size_t wpt_index,
                         size_t sample_index = 0) {
   return std::accumulate(N.begin(), N.begin() + wpt_index, size_t{0}) +
          sample_index;
 }
 
-/**
- * Returns a vector of linearly spaced elements between start exclusive and end
- * inclusive.
- *
- * @param start The initial value exclusive.
- * @param end The final value exclusive.
- * @param num_samples The number of samples in the vector.
- * @return A vector of linearly spaced elements between start exclusive and end
- *     inclusive.
- */
+/// Returns a vector of linearly spaced elements between start exclusive and end
+/// inclusive.
+///
+/// @param start The initial value exclusive.
+/// @param end The final value exclusive.
+/// @param num_samples The number of samples in the vector.
+/// @return A vector of linearly spaced elements between start exclusive and end
+///     inclusive.
 inline std::vector<double> linspace(double start, double end,
                                     size_t num_samples) {
   std::vector<double> result;
@@ -45,13 +41,11 @@ inline std::vector<double> linspace(double start, double end,
   return result;
 }
 
-/**
- * Returns modulus of input.
- *
- * @param input         Input value to wrap.
- * @param minimum_input The minimum value expected from the input.
- * @param maximum_input The maximum value expected from the input.
- */
+/// Returns modulus of input.
+///
+/// @param input Input value to wrap.
+/// @param minimum_input The minimum value expected from the input.
+/// @param maximum_input The maximum value expected from the input.
 constexpr double input_modulus(double input, double minimum_input,
                                double maximum_input) {
   double modulus = maximum_input - minimum_input;
@@ -67,38 +61,32 @@ constexpr double input_modulus(double input, double minimum_input,
   return input;
 }
 
-/**
- * Wraps an angle to the range -π to π radians (-180 to 180 degrees).
- *
- * @param angle Angle to wrap in radians.
- */
+/// Wraps an angle to the range -π to π radians (-180 to 180 degrees).
+///
+/// @param angle Angle to wrap in radians.
 constexpr double angle_modulus(double angle) {
   return input_modulus(angle, -std::numbers::pi, std::numbers::pi);
 }
 
-/**
- * Returns a vector of linearly spaced angles between start exclusive and end
- * inclusive.
- *
- * @param start The initial value exclusive.
- * @param end The final value exclusive.
- * @param num_samples The number of samples in the vector.
- * @return A vector of linearly spaced elements between start exclusive and end
- *     inclusive.
- */
+/// Returns a vector of linearly spaced angles between start exclusive and end
+/// inclusive.
+///
+/// @param start The initial value exclusive.
+/// @param end The final value exclusive.
+/// @param num_samples The number of samples in the vector.
+/// @return A vector of linearly spaced elements between start exclusive and end
+///     inclusive.
 inline std::vector<double> angle_linspace(double start, double end,
                                           size_t num_samples) {
   return linspace(start, start + angle_modulus(end - start), num_samples);
 }
 
-/**
- * Returns the time a trapezoid profile takes to travel a given distance from
- * rest to rest.
- *
- * @param distance The distance to travel.
- * @param velocity The profile's maximum velocity.
- * @param acceleration The profile's maximum acceleration.
- */
+/// Returns the time a trapezoid profile takes to travel a given distance from
+/// rest to rest.
+///
+/// @param distance The distance to travel.
+/// @param velocity The profile's maximum velocity.
+/// @param acceleration The profile's maximum acceleration.
 inline double calculate_trapezoidal_time(double distance, double velocity,
                                          double acceleration) {
   if (distance > ((velocity * velocity) / acceleration)) {

--- a/trajoptlib/src/rust_ffi.hpp
+++ b/trajoptlib/src/rust_ffi.hpp
@@ -89,15 +89,13 @@ class SwerveTrajectoryGenerator {
   void sgmt_keep_out_circle(size_t from_index, size_t to_index, double x,
                             double y, double radius);
 
-  /**
-   * Add a callback that will be called on each iteration of the solver.
-   *
-   * @param callback A `fn` (not a closure) to be executed. The callback's first
-   *   parameter will be a `trajopt::SwerveTrajectory`, and the second parameter
-   *   will be an `i64` equal to the handle passed in `generate()`.
-   *
-   * This function can be called multiple times to add multiple callbacks.
-   */
+  /// Add a callback that will be called on each iteration of the solver.
+  ///
+  /// This function can be called multiple times to add multiple callbacks.
+  ///
+  /// @param callback A `fn` (not a closure) to be executed. The callback's
+  ///     first parameter will be a `trajopt::SwerveTrajectory`, and the second
+  ///     parameter will be an `i64` equal to the handle passed in `generate()`.
   void add_callback(rust::Fn<void(SwerveTrajectory, int64_t)> callback);
 
   // TODO: Return std::expected<SwerveTrajectory, slp::SolverExitCondition>
@@ -166,15 +164,14 @@ class DifferentialTrajectoryGenerator {
   void sgmt_keep_out_circle(size_t from_index, size_t to_index, double x,
                             double y, double radius);
 
-  /**
-   * Add a callback that will be called on each iteration of the solver.
-   *
-   * @param callback A `fn` (not a closure) to be executed. The callback's first
-   *   parameter will be a `trajopt::DifferentialTrajectory`, and the second
-   *   parameter will be an `i64` equal to the handle passed in `generate()`.
-   *
-   * This function can be called multiple times to add multiple callbacks.
-   */
+  /// Add a callback that will be called on each iteration of the solver.
+  ///
+  /// This function can be called multiple times to add multiple callbacks.
+  ///
+  /// @param callback A `fn` (not a closure) to be executed. The callback's
+  ///     first parameter will be a `trajopt::DifferentialTrajectory`, and the
+  ///     second parameter will be an `i64` equal to the handle passed in
+  ///     `generate()`.
   void add_callback(rust::Fn<void(DifferentialTrajectory, int64_t)> callback);
 
   // TODO: Return std::expected<DifferentialTrajectory,


### PR DESCRIPTION
.java files still use multiline comments because spotless doesn't reflow triple forward slash comments correctly. Once it does, we can also remove the `<p>` tag spam.