### PR TITLE
Fix error feedback for schema being too new

### DIFF
--- a/src-core/src/error.rs
+++ b/src-core/src/error.rs
@@ -38,6 +38,8 @@ pub enum ChoreoError {
     HeadingConflict(usize, String),
     #[error("Remote Generation Error: {0}")]
     RemoteGenerationError(Box<ChoreoError>),
+    #[error("Update Choreo. File version too new: {0} > {1} on {2}")]
+    SchemaTooNew(usize, usize, String),
 }
 
 impl ChoreoError {

--- a/src-core/src/file_management/mod.rs
+++ b/src-core/src/file_management/mod.rs
@@ -199,7 +199,13 @@ pub async fn read_trajectory_file(
         .join(&name)
         .with_extension(TrajectoryFile::EXTENSION);
     let contents = fs::read_to_string(&path).await?;
-    let mut path = TrajectoryFile::from_content(&contents)?;
+    let mut path = TrajectoryFile::from_content(&contents).map_err(|e| {
+        if let ChoreoError::SchemaTooNew(actual, expected, _) = e {
+            ChoreoError::SchemaTooNew(actual, expected, format!("{}.traj", name))
+        } else {
+            e
+        }
+    })?;
     // this will keep the name of the `Path` in sync with the file name
     path.name = name;
     Ok(path)
@@ -298,7 +304,13 @@ pub async fn read_projectfile(
         .join(&name)
         .with_extension("chor");
     let contents = fs::read_to_string(&path).await?;
-    let mut project = ProjectFile::from_content(&contents)?;
+    let mut project = ProjectFile::from_content(&contents).map_err(|e| {
+        if let ChoreoError::SchemaTooNew(actual, expected, _) = e {
+            ChoreoError::SchemaTooNew(actual, expected, format!("{}.chor", name))
+        } else {
+            e
+        }
+    })?;
     project.name = name;
     Ok(project)
 }

--- a/src-core/src/file_management/upgrader.rs
+++ b/src-core/src/file_management/upgrader.rs
@@ -162,8 +162,16 @@ impl Upgrader {
     }
 
     pub fn upgrade(&self, jdata: JsonValue) -> ChoreoResult<JsonValue> {
-        let version =
-            get_version(&jdata).ok_or(ChoreoError::Json("Invalid JSON version".to_string()))?;
+        let version = get_version(&jdata)
+            .ok_or(ChoreoError::Json("Invalid JSON version".to_string()))?
+            as usize;
+        if version > self.actions.len() {
+            return Err(ChoreoError::SchemaTooNew(
+                version,
+                self.actions.len(),
+                "".to_string(),
+            ));
+        }
         let mut editor = Editor::new(jdata);
         for action in &self.actions[version as usize..] {
             action.upgrade(&mut editor)?;


### PR DESCRIPTION
This will fail on the first too-new file with a notice to update Choreo

