### PR TITLE
[trajoptlib] Upgrade to Sleipnir 0.5.2

### DIFF
--- a/trajoptlib/CMakeLists.txt
+++ b/trajoptlib/CMakeLists.txt
@@ -59,7 +59,7 @@ set(BUILD_EXAMPLES OFF)
 FetchContent_Declare(
     Sleipnir
     GIT_REPOSITORY https://github.com/SleipnirGroup/Sleipnir
-    GIT_TAG v0.5.1
+    GIT_TAG v0.5.2
     GIT_SHALLOW ON
     SYSTEM
 )

--- a/trajoptlib/src/error.rs
+++ b/trajoptlib/src/error.rs
@@ -13,6 +13,8 @@ pub enum TrajoptError {
     GloballyInfeasible,
     #[error("Factorization failed")]
     FactorizationFailed,
+    #[error("Line search failed")]
+    LineSearchFailed,
     #[error("Feasibility restoration failed")]
     FeasibilityRestorationFailed,
     #[error("Nonfinite initial guess")]
@@ -36,11 +38,12 @@ impl From<i8> for TrajoptError {
             -2 => Self::LocallyInfeasible,
             -3 => Self::GloballyInfeasible,
             -4 => Self::FactorizationFailed,
-            -5 => Self::FeasibilityRestorationFailed,
-            -6 => Self::NonfiniteInitialGuess,
-            -7 => Self::DivergingIterates,
-            -8 => Self::MaxIterationsExceeded,
-            -9 => Self::Timeout,
+            -5 => Self::LineSearchFailed,
+            -6 => Self::FeasibilityRestorationFailed,
+            -7 => Self::NonfiniteInitialGuess,
+            -8 => Self::DivergingIterates,
+            -9 => Self::MaxIterationsExceeded,
+            -10 => Self::Timeout,
             _ => Self::Unknown(value),
         }
     }


### PR DESCRIPTION
This fixes a bug in Sleipnir's Newton solver (the exit status was inaccurate because unconstrained optimization problems can't be infeasible). Choreo uses the interior-point method solver exclusively, so it'll never encounter the line search failure exit status.