### PR TITLE
docs: add name argument to SmartDashboard.putData in AutoChooser example

### DIFF
--- a/docs/choreolib/auto-factory.md
+++ b/docs/choreolib/auto-factory.md
@@ -294,7 +294,7 @@ public class Robot extends TimedRobot {
         autoChooser.addCmd("Example Auto Command", this::exampleAutoCommand);
 
         // Put the auto chooser on the dashboard
-        SmartDashboard.putData(autoChooser);
+        SmartDashboard.putData("Auto Chooser", autoChooser);
 
         // Schedule the selected auto during the autonomous period
         RobotModeTriggers.autonomous().whileTrue(autoChooser.selectedCommandScheduler());


### PR DESCRIPTION
## Summary

Add missing name argument to `SmartDashboard.putData()` in the AutoChooser documentation example.

## Motivation

Fixes #1446. The `SmartDashboard.putData(autoChooser)` call without a name argument results in the chooser being unusable from dashboards. The WPILib `SmartDashboard.putData(Sendable)` overload relies on the Sendable's default name, which may not be set properly for `AutoChooser`.

## Changes

- `docs/choreolib/auto-factory.md`: Changed `SmartDashboard.putData(autoChooser)` to `SmartDashboard.putData("Auto Chooser", autoChooser)` to use the explicit name overload.

## Verification

The fix follows the WPILib API convention where `SmartDashboard.putData(String, Sendable)` is the recommended way to register sendables with a human-readable name on the dashboard.