### PR TITLE
Fix clippy warning

### DIFF
--- a/src-core/src/file_management/upgrader.rs
+++ b/src-core/src/file_management/upgrader.rs
@@ -173,7 +173,7 @@ impl Upgrader {
             ));
         }
         let mut editor = Editor::new(jdata);
-        for action in &self.actions[version as usize..] {
+        for action in &self.actions[version..] {
             action.upgrade(&mut editor)?;
         }
         editor.set_path("version", self.current_version)?;


### PR DESCRIPTION
```
error: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src-core/src/file_management/upgrader.rs:176:37
    |
176 |         for action in &self.actions[version as usize..] {
    |                                     ^^^^^^^^^^^^^^^^ help: try: `version`
```