### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,56 +1,24 @@
-# Logs
-logs
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
-
-node_modules
-dist
-dist-ssr
-*.local
-
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
-
-# Choreo
-src-tauri/gen
-src-tauri/target
-target
-
-# TrajoptLib
-trajoptlib/build*
-trajoptlib/target
+build/
+node_modules/
+src-tauri/gen/
+target/
 trajoptlib/Cargo.lock
+
+# CMake
+CMakeUserPresets.json
 
 # Python
 *.egg-info/
-.eggs/
-.pytest_cache/
 __pycache__/
 dist/
 
-# clangd
-.cache
-compile_commands.json
+# Visual Studio Code
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+
+# macOS
+.DS_Store
 
 # mkdocs
 site/
-
-# cmake user presets
-CMakeUserPresets.json
-
-build/
-cli/
-test-tmp*/

--- a/src-core/src/integration_tests/generate.rs
+++ b/src-core/src/integration_tests/generate.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod generate {
+    use std::env::temp_dir;
     use std::fs;
     use std::{
         path::PathBuf,
@@ -22,14 +23,14 @@ mod generate {
     }
 
     async fn test_generate(drive_type: &str, version: &str) {
-        let test_dir: PathBuf = format!("./test-tmp-{version}-{drive_type}").into();
+        let test_dir: PathBuf = temp_dir().join(format!("choreo-test-{version}-{drive_type}"));
         let original_chor: PathBuf =
             format!("../test-jsons/project/{version}/{drive_type}.chor").into();
         let test_chor: PathBuf = test_dir.join(format!("{drive_type}.chor"));
         let original_traj: PathBuf =
             format!("../test-jsons/trajectory/{version}/{drive_type}.traj").into();
         let test_traj: PathBuf = test_dir.join(format!("{drive_type}.traj"));
-        let _ = fs::create_dir(test_dir.clone()).or_else(|_| fs::remove_dir(test_dir));
+        let _ = fs::create_dir(test_dir.clone());
         // don't modify the original files
         fs::copy(original_chor.clone(), test_chor.clone()).unwrap();
         fs::copy(original_traj.clone(), test_traj.clone()).unwrap();
@@ -46,6 +47,7 @@ mod generate {
         let chor_after_second = fs::read_to_string(test_chor.clone()).unwrap();
         assert!(traj_after_first == traj_after_second);
         assert!(chor_after_first == chor_after_second);
+        let _ = fs::remove_dir_all(test_dir);
     }
     // Copied from src-cli
     #[allow(clippy::cast_possible_wrap)]


### PR DESCRIPTION
I was able to eliminate some directories by having the integration tests use a temp directory instead.